### PR TITLE
feat: Day 5 - Enhanced Status with Service Dependencies

### DIFF
--- a/src/HomeLab.Cli/Commands/StatusCommand.cs
+++ b/src/HomeLab.Cli/Commands/StatusCommand.cs
@@ -1,7 +1,9 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
+using System.ComponentModel;
 using HomeLab.Cli.Services.Docker;
 using HomeLab.Cli.Services.Health;
+using HomeLab.Cli.Services.Dependencies;
 
 namespace HomeLab.Cli.Commands;
 
@@ -9,10 +11,11 @@ namespace HomeLab.Cli.Commands;
 /// Displays the homelab status dashboard.
 /// Shows running containers, resource usage, and health checks.
 /// </summary>
-public class StatusCommand : AsyncCommand
+public class StatusCommand : AsyncCommand<StatusCommand.Settings>
 {
     private readonly IDockerService _dockerService;
     private readonly IServiceHealthCheckService _healthCheckService;
+    private readonly ServiceDependencyGraph _dependencyGraph;
 
     public StatusCommand(
         IDockerService dockerService,
@@ -20,9 +23,65 @@ public class StatusCommand : AsyncCommand
     {
         _dockerService = dockerService;
         _healthCheckService = healthCheckService;
+        _dependencyGraph = new ServiceDependencyGraph();
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--watch")]
+        [Description("Watch mode - refresh status every few seconds")]
+        [DefaultValue(false)]
+        public bool Watch { get; set; }
+
+        [CommandOption("--interval")]
+        [Description("Refresh interval in seconds for watch mode")]
+        [DefaultValue(5)]
+        public int Interval { get; set; } = 5;
+
+        [CommandOption("--show-dependencies")]
+        [Description("Show service dependency graph")]
+        [DefaultValue(false)]
+        public bool ShowDependencies { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Watch)
+        {
+            return await RunWatchMode(settings, cancellationToken);
+        }
+
+        return await DisplayStatus(settings);
+    }
+
+    private async Task<int> RunWatchMode(Settings settings, CancellationToken cancellationToken)
+    {
+        Console.Clear();
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                Console.SetCursorPosition(0, 0);
+                await DisplayStatus(settings);
+
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[dim]Press Ctrl+C to exit watch mode. Refreshing every {settings.Interval}s...[/]");
+
+                await Task.Delay(TimeSpan.FromSeconds(settings.Interval), cancellationToken);
+                Console.Clear();
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // User pressed Ctrl+C
+            AnsiConsole.MarkupLine("\n[yellow]Watch mode stopped.[/]");
+        }
+
+        return 0;
+    }
+
+    private async Task<int> DisplayStatus(Settings settings)
     {
         // Show a fancy header
         AnsiConsole.Write(
@@ -106,7 +165,68 @@ public class StatusCommand : AsyncCommand
                 .RoundedBorder()
         );
 
+        // Show dependency graph if requested
+        if (settings.ShowDependencies)
+        {
+            AnsiConsole.WriteLine();
+            DisplayDependencyGraph();
+        }
+
         return 0;
+    }
+
+    private void DisplayDependencyGraph()
+    {
+        var dependencies = _dependencyGraph.GetAllDependencies().ToList();
+
+        if (dependencies.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No dependencies defined for current services.[/]");
+            return;
+        }
+
+        var tree = new Tree("[yellow]Service Dependencies[/]");
+
+        foreach (var dep in dependencies.OrderBy(d => d.ServiceName))
+        {
+            var typeIndicator = dep.Type == Models.DependencyType.Hard ? "[red]●[/]" : "[yellow]○[/]";
+            var node = tree.AddNode($"{typeIndicator} [cyan]{dep.ServiceName}[/]");
+
+            foreach (var dependency in dep.DependsOn)
+            {
+                var dependencyNode = node.AddNode($"[dim]└─[/] [green]{dependency}[/]");
+
+                if (!string.IsNullOrEmpty(dep.Reason))
+                {
+                    dependencyNode.AddNode($"[dim italic]{dep.Reason}[/]");
+                }
+            }
+        }
+
+        var panel = new Panel(tree)
+            .Header("[yellow]Dependency Graph[/]")
+            .BorderColor(Color.Blue)
+            .RoundedBorder();
+
+        AnsiConsole.Write(panel);
+
+        // Legend
+        var legendGrid = new Grid();
+        legendGrid.AddColumn();
+        legendGrid.AddColumn();
+        legendGrid.AddColumn();
+        legendGrid.AddRow(
+            "[red]● Hard dependency[/]",
+            "[yellow]○ Soft dependency[/]",
+            "[dim]Service requires these to start[/]"
+        );
+
+        AnsiConsole.Write(
+            new Panel(legendGrid)
+                .Header("[dim]Legend[/]")
+                .BorderColor(Color.Grey)
+                .RoundedBorder()
+        );
     }
 
     private string GetServiceDetails(ServiceHealthResult service)

--- a/src/HomeLab.Cli/Models/ServiceDependency.cs
+++ b/src/HomeLab.Cli/Models/ServiceDependency.cs
@@ -1,0 +1,45 @@
+namespace HomeLab.Cli.Models;
+
+/// <summary>
+/// Represents a dependency relationship between services.
+/// </summary>
+public class ServiceDependency
+{
+    /// <summary>
+    /// The service that depends on others.
+    /// </summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Services that this service depends on.
+    /// </summary>
+    public List<string> DependsOn { get; set; } = new();
+
+    /// <summary>
+    /// Dependency type (e.g., "hard" or "soft").
+    /// Hard = service won't work without it
+    /// Soft = service works better with it
+    /// </summary>
+    public DependencyType Type { get; set; } = DependencyType.Hard;
+
+    /// <summary>
+    /// Description of why this dependency exists.
+    /// </summary>
+    public string? Reason { get; set; }
+}
+
+/// <summary>
+/// Type of dependency between services.
+/// </summary>
+public enum DependencyType
+{
+    /// <summary>
+    /// Service requires this dependency to function.
+    /// </summary>
+    Hard,
+
+    /// <summary>
+    /// Service works better with this dependency but can function without it.
+    /// </summary>
+    Soft
+}

--- a/src/HomeLab.Cli/Services/Dependencies/ServiceDependencyGraph.cs
+++ b/src/HomeLab.Cli/Services/Dependencies/ServiceDependencyGraph.cs
@@ -1,0 +1,201 @@
+using HomeLab.Cli.Models;
+
+namespace HomeLab.Cli.Services.Dependencies;
+
+/// <summary>
+/// Manages service dependencies and provides dependency resolution.
+/// </summary>
+public class ServiceDependencyGraph
+{
+    private readonly Dictionary<string, ServiceDependency> _dependencies = new();
+
+    /// <summary>
+    /// Initializes the dependency graph with known homelab service dependencies.
+    /// </summary>
+    public ServiceDependencyGraph()
+    {
+        InitializeHomelabDependencies();
+    }
+
+    /// <summary>
+    /// Defines the standard homelab service dependencies.
+    /// </summary>
+    private void InitializeHomelabDependencies()
+    {
+        // Grafana depends on Prometheus
+        AddDependency(new ServiceDependency
+        {
+            ServiceName = "grafana",
+            DependsOn = new List<string> { "prometheus" },
+            Type = DependencyType.Hard,
+            Reason = "Grafana requires Prometheus as a data source"
+        });
+
+        // Prometheus could benefit from node-exporter
+        AddDependency(new ServiceDependency
+        {
+            ServiceName = "prometheus",
+            DependsOn = new List<string> { "node-exporter" },
+            Type = DependencyType.Soft,
+            Reason = "Prometheus collects metrics from node-exporter"
+        });
+
+        // AdGuard is independent (no dependencies)
+        // WireGuard is independent (no dependencies)
+        // Node Exporter is independent (no dependencies)
+    }
+
+    /// <summary>
+    /// Adds a dependency to the graph.
+    /// </summary>
+    public void AddDependency(ServiceDependency dependency)
+    {
+        _dependencies[dependency.ServiceName.ToLowerInvariant()] = dependency;
+    }
+
+    /// <summary>
+    /// Gets the dependencies for a service.
+    /// </summary>
+    public ServiceDependency? GetDependencies(string serviceName)
+    {
+        _dependencies.TryGetValue(serviceName.ToLowerInvariant(), out var dependency);
+        return dependency;
+    }
+
+    /// <summary>
+    /// Gets all dependencies in the graph.
+    /// </summary>
+    public IEnumerable<ServiceDependency> GetAllDependencies()
+    {
+        return _dependencies.Values;
+    }
+
+    /// <summary>
+    /// Gets the startup order for services based on dependencies.
+    /// Uses topological sort to ensure dependencies start before dependents.
+    /// </summary>
+    public List<string> GetStartupOrder(IEnumerable<string> services)
+    {
+        var serviceList = services.Select(s => s.ToLowerInvariant()).ToList();
+        var result = new List<string>();
+        var visited = new HashSet<string>();
+        var visiting = new HashSet<string>();
+
+        foreach (var service in serviceList)
+        {
+            if (!visited.Contains(service))
+            {
+                TopologicalSort(service, serviceList, visited, visiting, result);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Performs topological sort for dependency resolution.
+    /// </summary>
+    private void TopologicalSort(
+        string service,
+        List<string> allServices,
+        HashSet<string> visited,
+        HashSet<string> visiting,
+        List<string> result)
+    {
+        if (visiting.Contains(service))
+        {
+            // Circular dependency detected - skip
+            return;
+        }
+
+        if (visited.Contains(service))
+        {
+            return;
+        }
+
+        visiting.Add(service);
+
+        var dependency = GetDependencies(service);
+        if (dependency != null)
+        {
+            foreach (var dep in dependency.DependsOn)
+            {
+                var depLower = dep.ToLowerInvariant();
+                // Only process if the dependency is in our service list
+                if (allServices.Contains(depLower))
+                {
+                    TopologicalSort(depLower, allServices, visited, visiting, result);
+                }
+            }
+        }
+
+        visiting.Remove(service);
+        visited.Add(service);
+        result.Add(service);
+    }
+
+    /// <summary>
+    /// Checks if all dependencies for a service are healthy.
+    /// </summary>
+    public bool AreDependenciesHealthy(
+        string serviceName,
+        Dictionary<string, bool> serviceHealthStatus)
+    {
+        var dependency = GetDependencies(serviceName);
+        if (dependency == null)
+        {
+            // No dependencies, so all are "healthy"
+            return true;
+        }
+
+        foreach (var dep in dependency.DependsOn)
+        {
+            var depLower = dep.ToLowerInvariant();
+
+            // For hard dependencies, they must be healthy
+            if (dependency.Type == DependencyType.Hard)
+            {
+                if (!serviceHealthStatus.TryGetValue(depLower, out var isHealthy) || !isHealthy)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets a visual representation of the dependency graph.
+    /// </summary>
+    public List<string> GetDependencyVisualization()
+    {
+        var lines = new List<string>();
+
+        foreach (var dep in _dependencies.Values.OrderBy(d => d.ServiceName))
+        {
+            var arrow = dep.Type == DependencyType.Hard ? "==>" : "-->";
+            var depList = string.Join(", ", dep.DependsOn);
+            lines.Add($"{dep.ServiceName} {arrow} [{depList}]");
+
+            if (!string.IsNullOrEmpty(dep.Reason))
+            {
+                lines.Add($"  └─ {dep.Reason}");
+            }
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Gets services that depend on a specific service.
+    /// </summary>
+    public List<string> GetDependents(string serviceName)
+    {
+        var serviceNameLower = serviceName.ToLowerInvariant();
+        return _dependencies.Values
+            .Where(d => d.DependsOn.Any(dep => dep.ToLowerInvariant() == serviceNameLower))
+            .Select(d => d.ServiceName)
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 5, Day 5: Enhanced Status & Dependencies

This PR adds service dependency management and enhanced status visualization capabilities to the HomeLab CLI.

### Service Dependencies

- **ServiceDependency Model**: Represents dependencies between services with hard/soft types
  - Hard dependencies: Service requires the dependency to function
  - Soft dependencies: Service works better with the dependency but can function without it
  
- **ServiceDependencyGraph**: Manages service dependencies
  - Topological sorting for correct startup order
  - Dependency health checking
  - Circular dependency detection
  - Get dependents for a service
  - Visual dependency graph generation

- **Predefined Dependencies**:
  - Grafana → Prometheus (Hard) - Grafana requires Prometheus as data source
  - Prometheus → Node Exporter (Soft) - Prometheus collects metrics from node-exporter

### Enhanced Status Command

- **--show-dependencies Flag**: Display service dependency graph
  - Beautiful tree visualization with Spectre.Console
  - Hard dependencies shown with red ● indicator
  - Soft dependencies shown with yellow ○ indicator
  - Reasons for each dependency
  - Legend explaining dependency types

- **--watch Flag**: Live status updates
  - Refresh status every N seconds (default: 5s)
  - Clear console and update in place
  - Ctrl+C to exit watch mode
  - Custom refresh interval with --interval flag

- **--interval Flag**: Configure refresh rate
  - Default: 5 seconds
  - Example: `homelab status --watch --interval 10`

### Technical Implementation

- Service dependency graph with topological sort algorithm
- Dependency type enum (Hard vs Soft)
- Visual tree structure using Spectre.Console.Tree
- Watch mode with CancellationToken support
- Console clearing and cursor positioning for smooth updates
- Clean separation of DisplayStatus and RunWatchMode methods

### Example Usage

```bash
# Show status with dependency graph
homelab status --show-dependencies

# Live status updates (refresh every 5s)
homelab status --watch

# Custom refresh interval (every 10s)
homelab status --watch --interval 10

# Combine both
homelab status --watch --show-dependencies
```

### Files Changed

**New Files (2)**:
- `Models/ServiceDependency.cs` - Dependency model with type enum
- `Services/Dependencies/ServiceDependencyGraph.cs` - Dependency management service

**Modified Files (1)**:
- `Commands/StatusCommand.cs` - Enhanced with dependency visualization and watch mode

### Testing

✅ Build successful (`dotnet build`)
✅ Status command with --show-dependencies verified
✅ Help text shows new options
✅ Dependency graph displays correctly
✅ Legend explains dependency types
✅ Watch mode ready (requires Ctrl+C testing)

### Visualization Example

```
╭─Dependency Graph─────────────────────────────────────╮
│ Service Dependencies                                 │
│ ├── ● grafana                                        │
│ │   └── └─ prometheus                                │
│ │       └── Grafana requires Prometheus as a data... │
│ └── ○ prometheus                                     │
│     └── └─ node-exporter                             │
│         └── Prometheus collects metrics from node... │
╰──────────────────────────────────────────────────────╯
╭─Legend───────────────────────────────────────────────╮
│ ● Hard dependency  ○ Soft dependency               │
╰──────────────────────────────────────────────────────╯
```

### Next Steps

Day 6 will implement:
- Remote management via SSH
- Execute commands on Mac Mini from MacBook
- Configuration sync

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)