### PR TITLE
feat: Day 6 - Remote Management via SSH

### DIFF
--- a/src/HomeLab.Cli/Commands/Remote/RemoteConnectCommand.cs
+++ b/src/HomeLab.Cli/Commands/Remote/RemoteConnectCommand.cs
@@ -1,0 +1,171 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Remote;
+
+namespace HomeLab.Cli.Commands.Remote;
+
+/// <summary>
+/// Adds or updates a remote connection profile.
+/// </summary>
+public class RemoteConnectCommand : AsyncCommand<RemoteConnectCommand.Settings>
+{
+    private readonly RemoteConnectionService _connectionService;
+    private readonly ISshService _sshService;
+
+    public RemoteConnectCommand()
+    {
+        _connectionService = new RemoteConnectionService();
+        _sshService = new SshService();
+    }
+
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<name>")]
+        [Description("Name for this connection (e.g., 'mac-mini', 'production')")]
+        public string Name { get; set; } = string.Empty;
+
+        [CommandArgument(1, "<host>")]
+        [Description("Remote host (IP address or hostname)")]
+        public string Host { get; set; } = string.Empty;
+
+        [CommandOption("-u|--username")]
+        [Description("SSH username")]
+        public string? Username { get; set; }
+
+        [CommandOption("-p|--port")]
+        [Description("SSH port")]
+        [DefaultValue(22)]
+        public int Port { get; set; } = 22;
+
+        [CommandOption("-k|--key-file")]
+        [Description("Path to SSH private key file")]
+        public string? KeyFile { get; set; }
+
+        [CommandOption("--docker-socket")]
+        [Description("Docker socket path on remote host")]
+        [DefaultValue("unix:///var/run/docker.sock")]
+        public string DockerSocket { get; set; } = "unix:///var/run/docker.sock";
+
+        [CommandOption("--compose-file")]
+        [Description("Path to docker-compose.yml on remote host")]
+        public string? ComposeFile { get; set; }
+
+        [CommandOption("--default")]
+        [Description("Set this as the default connection")]
+        [DefaultValue(false)]
+        public bool SetDefault { get; set; }
+
+        [CommandOption("--test")]
+        [Description("Test the connection before saving")]
+        [DefaultValue(true)]
+        public bool TestConnection { get; set; } = true;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Remote Connect")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        // Get username if not provided
+        var username = settings.Username;
+        if (string.IsNullOrEmpty(username))
+        {
+            username = AnsiConsole.Ask<string>("SSH username:");
+        }
+
+        // Create connection profile
+        var connection = new RemoteConnection
+        {
+            Name = settings.Name,
+            Host = settings.Host,
+            Port = settings.Port,
+            Username = username,
+            KeyFile = settings.KeyFile,
+            DockerSocket = settings.DockerSocket,
+            ComposeFilePath = settings.ComposeFile,
+            IsDefault = settings.SetDefault
+        };
+
+        // Test connection if requested
+        if (settings.TestConnection)
+        {
+            AnsiConsole.MarkupLine($"[blue]Testing connection to {settings.Host}...[/]");
+
+            var testResult = await AnsiConsole.Status()
+                .StartAsync("Connecting...", async ctx =>
+                {
+                    ctx.Spinner(Spinner.Known.Dots);
+                    return await _sshService.TestConnectionAsync(connection);
+                });
+
+            if (!testResult)
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] Connection test failed!");
+                AnsiConsole.MarkupLine("[yellow]Save anyway?[/]");
+
+                if (!AnsiConsole.Confirm("Continue?", defaultValue: false))
+                {
+                    return 1;
+                }
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[green]✓[/] Connection successful!");
+
+                // Check if Docker is running
+                var dockerRunning = await _sshService.IsDockerRunningAsync(connection);
+                if (dockerRunning)
+                {
+                    AnsiConsole.MarkupLine("[green]✓[/] Docker is running on remote host");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]⚠[/] Docker may not be running on remote host");
+                }
+
+                connection.LastConnected = DateTime.UtcNow;
+            }
+        }
+
+        // Save connection
+        _connectionService.AddConnection(connection);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[green]✓[/] Connection profile '[cyan]{settings.Name}[/]' saved");
+
+        if (settings.SetDefault)
+        {
+            _connectionService.SetDefaultConnection(settings.Name);
+            AnsiConsole.MarkupLine($"[green]✓[/] Set as default connection");
+        }
+
+        // Show connection details
+        AnsiConsole.WriteLine();
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]Property[/]");
+        table.AddColumn("[yellow]Value[/]");
+
+        table.AddRow("Name", $"[cyan]{connection.Name}[/]");
+        table.AddRow("Host", connection.Host);
+        table.AddRow("Port", connection.Port.ToString());
+        table.AddRow("Username", connection.Username);
+        table.AddRow("Key File", connection.KeyFile ?? "[dim]none (will use SSH agent)[/]");
+        table.AddRow("Docker Socket", $"[dim]{connection.DockerSocket}[/]");
+        table.AddRow("Compose File", connection.ComposeFilePath ?? "[dim]not set[/]");
+        table.AddRow("Default", connection.IsDefault ? "[green]Yes[/]" : "[dim]No[/]");
+
+        AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[dim]Use 'homelab remote status {0}' to check remote homelab status[/]", settings.Name);
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Commands/Remote/RemoteListCommand.cs
+++ b/src/HomeLab.Cli/Commands/Remote/RemoteListCommand.cs
@@ -1,0 +1,86 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using HomeLab.Cli.Services.Remote;
+
+namespace HomeLab.Cli.Commands.Remote;
+
+/// <summary>
+/// Lists all configured remote connections.
+/// </summary>
+public class RemoteListCommand : Command
+{
+    private readonly RemoteConnectionService _connectionService;
+
+    public RemoteListCommand()
+    {
+        _connectionService = new RemoteConnectionService();
+    }
+
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
+    {
+        var connections = _connectionService.ListConnections();
+
+        if (connections.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No remote connections configured.[/]");
+            AnsiConsole.MarkupLine("\n[dim]Add a connection with:[/]");
+            AnsiConsole.MarkupLine("  [cyan]homelab remote connect <name> <host> -u <username>[/]");
+            return 0;
+        }
+
+        AnsiConsole.Write(
+            new FigletText("Remote Connections")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]Name[/]");
+        table.AddColumn("[yellow]Host[/]");
+        table.AddColumn("[yellow]Username[/]");
+        table.AddColumn("[yellow]Port[/]");
+        table.AddColumn("[yellow]Default[/]");
+        table.AddColumn("[yellow]Last Connected[/]");
+
+        foreach (var conn in connections.OrderBy(c => c.Name))
+        {
+            var defaultIndicator = conn.IsDefault ? "⭐" : "";
+            var lastConnected = conn.LastConnected.HasValue
+                ? FormatTimeAgo(conn.LastConnected.Value)
+                : "[dim]Never[/]";
+
+            table.AddRow(
+                $"{defaultIndicator} [cyan]{conn.Name}[/]",
+                conn.Host,
+                conn.Username,
+                conn.Port.ToString(),
+                conn.IsDefault ? "[green]Yes[/]" : "[dim]No[/]",
+                lastConnected
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[green]Total connections:[/] {connections.Count}");
+
+        return 0;
+    }
+
+    private string FormatTimeAgo(DateTime dateTime)
+    {
+        var timeAgo = DateTime.UtcNow - dateTime;
+
+        if (timeAgo.TotalMinutes < 1)
+            return "[green]Just now[/]";
+        if (timeAgo.TotalMinutes < 60)
+            return $"[dim]{(int)timeAgo.TotalMinutes}m ago[/]";
+        if (timeAgo.TotalHours < 24)
+            return $"[dim]{(int)timeAgo.TotalHours}h ago[/]";
+        if (timeAgo.TotalDays < 7)
+            return $"[dim]{(int)timeAgo.TotalDays}d ago[/]";
+        return $"[dim]{dateTime:yyyy-MM-dd}[/]";
+    }
+}

--- a/src/HomeLab.Cli/Commands/Remote/RemoteRemoveCommand.cs
+++ b/src/HomeLab.Cli/Commands/Remote/RemoteRemoveCommand.cs
@@ -1,0 +1,76 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+using HomeLab.Cli.Services.Remote;
+
+namespace HomeLab.Cli.Commands.Remote;
+
+/// <summary>
+/// Removes a remote connection profile.
+/// </summary>
+public class RemoteRemoveCommand : Command<RemoteRemoveCommand.Settings>
+{
+    private readonly RemoteConnectionService _connectionService;
+
+    public RemoteRemoveCommand()
+    {
+        _connectionService = new RemoteConnectionService();
+    }
+
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<name>")]
+        [Description("Connection name to remove")]
+        public string Name { get; set; } = string.Empty;
+
+        [CommandOption("-y|--yes")]
+        [Description("Skip confirmation prompt")]
+        [DefaultValue(false)]
+        public bool SkipConfirmation { get; set; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var connection = _connectionService.GetConnection(settings.Name);
+
+        if (connection == null)
+        {
+            AnsiConsole.MarkupLine($"[red]✗[/] Connection '[cyan]{settings.Name}[/]' not found");
+            return 1;
+        }
+
+        // Show connection details
+        AnsiConsole.MarkupLine($"\n[yellow]Removing connection:[/] [cyan]{connection.Name}[/]");
+        AnsiConsole.MarkupLine($"[dim]Host:[/] {connection.Host}");
+        AnsiConsole.MarkupLine($"[dim]User:[/] {connection.Username}");
+
+        if (connection.IsDefault)
+        {
+            AnsiConsole.MarkupLine("[yellow]⚠ This is the default connection[/]");
+        }
+
+        // Confirm removal
+        if (!settings.SkipConfirmation)
+        {
+            if (!AnsiConsole.Confirm("\nAre you sure you want to remove this connection?", defaultValue: false))
+            {
+                AnsiConsole.MarkupLine("[yellow]Cancelled[/]");
+                return 0;
+            }
+        }
+
+        // Remove connection
+        var removed = _connectionService.RemoveConnection(settings.Name);
+
+        if (removed)
+        {
+            AnsiConsole.MarkupLine($"\n[green]✓[/] Connection '[cyan]{settings.Name}[/]' removed");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"\n[red]✗[/] Failed to remove connection");
+            return 1;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/Remote/RemoteStatusCommand.cs
+++ b/src/HomeLab.Cli/Commands/Remote/RemoteStatusCommand.cs
@@ -1,0 +1,170 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+using HomeLab.Cli.Services.Remote;
+
+namespace HomeLab.Cli.Commands.Remote;
+
+/// <summary>
+/// Displays status of a remote homelab.
+/// </summary>
+public class RemoteStatusCommand : AsyncCommand<RemoteStatusCommand.Settings>
+{
+    private readonly RemoteConnectionService _connectionService;
+    private readonly ISshService _sshService;
+
+    public RemoteStatusCommand()
+    {
+        _connectionService = new RemoteConnectionService();
+        _sshService = new SshService();
+    }
+
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "[name]")]
+        [Description("Connection name (uses default if not specified)")]
+        public string? Name { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        // Get connection
+        var connection = string.IsNullOrEmpty(settings.Name)
+            ? _connectionService.GetDefaultConnection()
+            : _connectionService.GetConnection(settings.Name);
+
+        if (connection == null)
+        {
+            if (string.IsNullOrEmpty(settings.Name))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] No default connection configured");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[red]✗[/] Connection '[cyan]{settings.Name}[/]' not found");
+            }
+
+            AnsiConsole.MarkupLine("\n[dim]List connections with:[/]");
+            AnsiConsole.MarkupLine("  [cyan]homelab remote list[/]");
+            return 1;
+        }
+
+        AnsiConsole.Write(
+            new FigletText($"Remote: {connection.Name}")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        // Test connection
+        AnsiConsole.MarkupLine($"[blue]Connecting to {connection.Host}...[/]");
+
+        var isConnected = await AnsiConsole.Status()
+            .StartAsync("Testing connection...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                return await _sshService.TestConnectionAsync(connection);
+            });
+
+        if (!isConnected)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Failed to connect to remote host");
+            AnsiConsole.MarkupLine($"[dim]Host:[/] {connection.Host}:{connection.Port}");
+            AnsiConsole.MarkupLine($"[dim]User:[/] {connection.Username}");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] Connected successfully\n");
+
+        // Update last connected timestamp
+        connection.LastConnected = DateTime.UtcNow;
+        _connectionService.AddConnection(connection);
+
+        // Check Docker status
+        var dockerRunning = await AnsiConsole.Status()
+            .StartAsync("Checking Docker status...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                return await _sshService.IsDockerRunningAsync(connection);
+            });
+
+        if (!dockerRunning)
+        {
+            AnsiConsole.MarkupLine("[yellow]⚠[/] Docker is not running on remote host");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] Docker is running\n");
+
+        // Get Docker info
+        var dockerInfo = await _sshService.ExecuteCommandAsync(connection, "docker info --format '{{.ServerVersion}}|||{{.NCPU}}|||{{.MemTotal}}'");
+
+        if (dockerInfo.Success)
+        {
+            var parts = dockerInfo.Output.Trim().Split("|||");
+            if (parts.Length >= 3)
+            {
+                var table = new Table();
+                table.Border(TableBorder.Rounded);
+                table.AddColumn("[yellow]Property[/]");
+                table.AddColumn("[yellow]Value[/]");
+
+                table.AddRow("Host", $"[cyan]{connection.Host}[/]");
+                table.AddRow("Docker Version", parts[0].Trim());
+                table.AddRow("CPUs", parts[1].Trim());
+                table.AddRow("Memory", FormatBytes(parts[2].Trim()));
+
+                AnsiConsole.Write(table);
+            }
+        }
+
+        // Get running containers
+        AnsiConsole.WriteLine();
+        var containersResult = await _sshService.ExecuteCommandAsync(connection, "docker ps --format '{{.Names}}|||{{.Status}}|||{{.Image}}'");
+
+        if (containersResult.Success && !string.IsNullOrWhiteSpace(containersResult.Output))
+        {
+            var containers = containersResult.Output.Trim().Split('\n');
+
+            var containerTable = new Table();
+            containerTable.Border(TableBorder.Rounded);
+            containerTable.AddColumn("[yellow]Container[/]");
+            containerTable.AddColumn("[yellow]Status[/]");
+            containerTable.AddColumn("[yellow]Image[/]");
+
+            foreach (var container in containers)
+            {
+                var parts = container.Split("|||");
+                if (parts.Length >= 3)
+                {
+                    var status = parts[1].Contains("Up") ? $"[green]{parts[1]}[/]" : $"[red]{parts[1]}[/]";
+                    containerTable.AddRow(
+                        $"[cyan]{parts[0]}[/]",
+                        status,
+                        $"[dim]{parts[2]}[/]"
+                    );
+                }
+            }
+
+            AnsiConsole.Write(containerTable);
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[green]Running containers:[/] {containers.Length}");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[yellow]No containers running[/]");
+        }
+
+        return 0;
+    }
+
+    private string FormatBytes(string bytesStr)
+    {
+        if (long.TryParse(bytesStr, out var bytes))
+        {
+            var gb = bytes / (1024.0 * 1024.0 * 1024.0);
+            return $"{gb:F2} GB";
+        }
+        return bytesStr;
+    }
+}

--- a/src/HomeLab.Cli/Commands/Remote/RemoteSyncCommand.cs
+++ b/src/HomeLab.Cli/Commands/Remote/RemoteSyncCommand.cs
@@ -1,0 +1,197 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+using HomeLab.Cli.Services.Remote;
+
+namespace HomeLab.Cli.Commands.Remote;
+
+/// <summary>
+/// Syncs docker-compose files between local and remote.
+/// </summary>
+public class RemoteSyncCommand : AsyncCommand<RemoteSyncCommand.Settings>
+{
+    private readonly RemoteConnectionService _connectionService;
+    private readonly ISshService _sshService;
+
+    public RemoteSyncCommand()
+    {
+        _connectionService = new RemoteConnectionService();
+        _sshService = new SshService();
+    }
+
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "[name]")]
+        [Description("Connection name (uses default if not specified)")]
+        public string? Name { get; set; }
+
+        [CommandOption("--push")]
+        [Description("Push local docker-compose.yml to remote")]
+        [DefaultValue(false)]
+        public bool Push { get; set; }
+
+        [CommandOption("--pull")]
+        [Description("Pull remote docker-compose.yml to local")]
+        [DefaultValue(false)]
+        public bool Pull { get; set; }
+
+        [CommandOption("--local-file")]
+        [Description("Local docker-compose.yml file path")]
+        public string? LocalFile { get; set; }
+
+        [CommandOption("--remote-file")]
+        [Description("Remote docker-compose.yml file path")]
+        public string? RemoteFile { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        // Validate direction
+        if (!settings.Push && !settings.Pull)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Please specify --push or --pull");
+            return 1;
+        }
+
+        if (settings.Push && settings.Pull)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Cannot specify both --push and --pull");
+            return 1;
+        }
+
+        // Get connection
+        var connection = string.IsNullOrEmpty(settings.Name)
+            ? _connectionService.GetDefaultConnection()
+            : _connectionService.GetConnection(settings.Name);
+
+        if (connection == null)
+        {
+            if (string.IsNullOrEmpty(settings.Name))
+            {
+                AnsiConsole.MarkupLine("[red]✗[/] No default connection configured");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[red]✗[/] Connection '[cyan]{settings.Name}[/]' not found");
+            }
+            return 1;
+        }
+
+        // Determine file paths
+        var localFile = settings.LocalFile ?? "docker-compose.yml";
+        var remoteFile = settings.RemoteFile ?? connection.ComposeFilePath ?? "~/docker-compose.yml";
+
+        // Expand ~ in remote file path
+        if (remoteFile.StartsWith("~/"))
+        {
+            var homeResult = await _sshService.ExecuteCommandAsync(connection, "echo $HOME");
+            if (homeResult.Success)
+            {
+                var home = homeResult.Output.Trim();
+                remoteFile = remoteFile.Replace("~", home);
+            }
+        }
+
+        AnsiConsole.Write(
+            new FigletText("Remote Sync")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        if (settings.Push)
+        {
+            return await PushFile(connection, localFile, remoteFile);
+        }
+        else
+        {
+            return await PullFile(connection, remoteFile, localFile);
+        }
+    }
+
+    private async Task<int> PushFile(Models.RemoteConnection connection, string localFile, string remoteFile)
+    {
+        AnsiConsole.MarkupLine($"[blue]Pushing local file to remote...[/]");
+        AnsiConsole.MarkupLine($"[dim]Local:[/]  {localFile}");
+        AnsiConsole.MarkupLine($"[dim]Remote:[/] {remoteFile}\n");
+
+        if (!File.Exists(localFile))
+        {
+            AnsiConsole.MarkupLine($"[red]✗[/] Local file not found: {localFile}");
+            return 1;
+        }
+
+        try
+        {
+            await AnsiConsole.Status()
+                .StartAsync("Uploading file...", async ctx =>
+                {
+                    ctx.Spinner(Spinner.Known.Dots);
+                    await _sshService.UploadFileAsync(connection, localFile, remoteFile);
+                });
+
+            AnsiConsole.MarkupLine("[green]✓[/] File uploaded successfully");
+
+            // Show file info
+            var fileInfo = new FileInfo(localFile);
+            AnsiConsole.MarkupLine($"[dim]Size:[/] {FormatBytes(fileInfo.Length)}");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]✗[/] Upload failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private async Task<int> PullFile(Models.RemoteConnection connection, string remoteFile, string localFile)
+    {
+        AnsiConsole.MarkupLine($"[blue]Pulling remote file to local...[/]");
+        AnsiConsole.MarkupLine($"[dim]Remote:[/] {remoteFile}");
+        AnsiConsole.MarkupLine($"[dim]Local:[/]  {localFile}\n");
+
+        // Check if local file exists and confirm overwrite
+        if (File.Exists(localFile))
+        {
+            AnsiConsole.MarkupLine($"[yellow]⚠[/] Local file exists: {localFile}");
+            if (!AnsiConsole.Confirm("Overwrite?", defaultValue: false))
+            {
+                AnsiConsole.MarkupLine("[yellow]Cancelled[/]");
+                return 0;
+            }
+        }
+
+        try
+        {
+            await AnsiConsole.Status()
+                .StartAsync("Downloading file...", async ctx =>
+                {
+                    ctx.Spinner(Spinner.Known.Dots);
+                    await _sshService.DownloadFileAsync(connection, remoteFile, localFile);
+                });
+
+            AnsiConsole.MarkupLine("[green]✓[/] File downloaded successfully");
+
+            // Show file info
+            var fileInfo = new FileInfo(localFile);
+            AnsiConsole.MarkupLine($"[dim]Size:[/] {FormatBytes(fileInfo.Length)}");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]✗[/] Download failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+            return $"{bytes} B";
+        if (bytes < 1024 * 1024)
+            return $"{bytes / 1024.0:F2} KB";
+        return $"{bytes / (1024.0 * 1024.0):F2} MB";
+    }
+}

--- a/src/HomeLab.Cli/Models/RemoteConnection.cs
+++ b/src/HomeLab.Cli/Models/RemoteConnection.cs
@@ -1,0 +1,113 @@
+namespace HomeLab.Cli.Models;
+
+/// <summary>
+/// Represents a remote homelab connection profile.
+/// </summary>
+public class RemoteConnection
+{
+    /// <summary>
+    /// Unique name for this connection (e.g., "mac-mini", "production").
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Remote host (IP address or hostname).
+    /// </summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>
+    /// SSH port (default: 22).
+    /// </summary>
+    public int Port { get; set; } = 22;
+
+    /// <summary>
+    /// SSH username.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Path to SSH private key file (optional if using password).
+    /// </summary>
+    public string? KeyFile { get; set; }
+
+    /// <summary>
+    /// Docker socket path on remote host.
+    /// </summary>
+    public string DockerSocket { get; set; } = "unix:///var/run/docker.sock";
+
+    /// <summary>
+    /// Path to docker-compose.yml on remote host.
+    /// </summary>
+    public string? ComposeFilePath { get; set; }
+
+    /// <summary>
+    /// Whether this is the default connection.
+    /// </summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>
+    /// Last successful connection timestamp.
+    /// </summary>
+    public DateTime? LastConnected { get; set; }
+
+    /// <summary>
+    /// Optional description/notes.
+    /// </summary>
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Collection of remote connection profiles.
+/// </summary>
+public class RemoteConnectionProfiles
+{
+    /// <summary>
+    /// List of all configured remote connections.
+    /// </summary>
+    public List<RemoteConnection> Connections { get; set; } = new();
+
+    /// <summary>
+    /// Gets the default connection if one is set.
+    /// </summary>
+    public RemoteConnection? GetDefaultConnection()
+    {
+        return Connections.FirstOrDefault(c => c.IsDefault);
+    }
+
+    /// <summary>
+    /// Gets a connection by name.
+    /// </summary>
+    public RemoteConnection? GetConnection(string name)
+    {
+        return Connections.FirstOrDefault(c =>
+            c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Adds or updates a connection.
+    /// </summary>
+    public void AddOrUpdateConnection(RemoteConnection connection)
+    {
+        var existing = GetConnection(connection.Name);
+        if (existing != null)
+        {
+            Connections.Remove(existing);
+        }
+
+        Connections.Add(connection);
+    }
+
+    /// <summary>
+    /// Removes a connection by name.
+    /// </summary>
+    public bool RemoveConnection(string name)
+    {
+        var connection = GetConnection(name);
+        if (connection != null)
+        {
+            Connections.Remove(connection);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -4,6 +4,7 @@ using HomeLab.Cli.Commands;
 using HomeLab.Cli.Commands.Dns;
 using HomeLab.Cli.Commands.Monitor;
 using HomeLab.Cli.Commands.Vpn;
+using HomeLab.Cli.Commands.Remote;
 using HomeLab.Cli.Services.Docker;
 using HomeLab.Cli.Services.Configuration;
 using HomeLab.Cli.Services.Health;
@@ -98,6 +99,22 @@ public static class Program
                     .WithDescription("Display Prometheus scrape targets");
                 monitor.AddCommand<MonitorDashboardCommand>("dashboard")
                     .WithDescription("Open Grafana dashboards");
+            });
+
+            // Phase 5 - Day 6: Remote Management
+            config.AddBranch("remote", remote =>
+            {
+                remote.SetDescription("Manage remote homelab connections");
+                remote.AddCommand<RemoteConnectCommand>("connect")
+                    .WithDescription("Add or update a remote connection");
+                remote.AddCommand<RemoteListCommand>("list")
+                    .WithDescription("List all configured remote connections");
+                remote.AddCommand<RemoteStatusCommand>("status")
+                    .WithDescription("Check status of remote homelab");
+                remote.AddCommand<RemoteSyncCommand>("sync")
+                    .WithDescription("Sync docker-compose files with remote");
+                remote.AddCommand<RemoteRemoveCommand>("remove")
+                    .WithDescription("Remove a remote connection");
             });
         });
 

--- a/src/HomeLab.Cli/Services/Remote/ISshService.cs
+++ b/src/HomeLab.Cli/Services/Remote/ISshService.cs
@@ -1,0 +1,60 @@
+using HomeLab.Cli.Models;
+
+namespace HomeLab.Cli.Services.Remote;
+
+/// <summary>
+/// Service for executing commands on remote hosts via SSH.
+/// </summary>
+public interface ISshService
+{
+    /// <summary>
+    /// Tests if a connection to the remote host is successful.
+    /// </summary>
+    Task<bool> TestConnectionAsync(RemoteConnection connection);
+
+    /// <summary>
+    /// Executes a command on the remote host and returns the output.
+    /// </summary>
+    Task<CommandResult> ExecuteCommandAsync(RemoteConnection connection, string command);
+
+    /// <summary>
+    /// Uploads a file to the remote host.
+    /// </summary>
+    Task UploadFileAsync(RemoteConnection connection, string localPath, string remotePath);
+
+    /// <summary>
+    /// Downloads a file from the remote host.
+    /// </summary>
+    Task DownloadFileAsync(RemoteConnection connection, string remotePath, string localPath);
+
+    /// <summary>
+    /// Checks if Docker is running on the remote host.
+    /// </summary>
+    Task<bool> IsDockerRunningAsync(RemoteConnection connection);
+}
+
+/// <summary>
+/// Result of executing a remote command.
+/// </summary>
+public class CommandResult
+{
+    /// <summary>
+    /// Exit code of the command (0 = success).
+    /// </summary>
+    public int ExitCode { get; set; }
+
+    /// <summary>
+    /// Standard output from the command.
+    /// </summary>
+    public string Output { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Standard error from the command.
+    /// </summary>
+    public string Error { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the command succeeded (exit code 0).
+    /// </summary>
+    public bool Success => ExitCode == 0;
+}

--- a/src/HomeLab.Cli/Services/Remote/RemoteConnectionService.cs
+++ b/src/HomeLab.Cli/Services/Remote/RemoteConnectionService.cs
@@ -1,0 +1,138 @@
+using HomeLab.Cli.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace HomeLab.Cli.Services.Remote;
+
+/// <summary>
+/// Service for managing remote connection profiles.
+/// Stores connections in ~/.homelab/remotes.yaml
+/// </summary>
+public class RemoteConnectionService
+{
+    private readonly string _profilesPath;
+    private readonly ISerializer _serializer;
+    private readonly IDeserializer _deserializer;
+
+    public RemoteConnectionService()
+    {
+        var homelabDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".homelab");
+
+        Directory.CreateDirectory(homelabDir);
+        _profilesPath = Path.Combine(homelabDir, "remotes.yaml");
+
+        _serializer = new SerializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .Build();
+
+        _deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .Build();
+    }
+
+    /// <summary>
+    /// Loads all remote connection profiles.
+    /// </summary>
+    public RemoteConnectionProfiles LoadProfiles()
+    {
+        if (!File.Exists(_profilesPath))
+        {
+            return new RemoteConnectionProfiles();
+        }
+
+        try
+        {
+            var yaml = File.ReadAllText(_profilesPath);
+            var profiles = _deserializer.Deserialize<RemoteConnectionProfiles>(yaml);
+            return profiles ?? new RemoteConnectionProfiles();
+        }
+        catch
+        {
+            return new RemoteConnectionProfiles();
+        }
+    }
+
+    /// <summary>
+    /// Saves remote connection profiles.
+    /// </summary>
+    public void SaveProfiles(RemoteConnectionProfiles profiles)
+    {
+        var yaml = _serializer.Serialize(profiles);
+        File.WriteAllText(_profilesPath, yaml);
+    }
+
+    /// <summary>
+    /// Adds a new connection profile.
+    /// </summary>
+    public void AddConnection(RemoteConnection connection)
+    {
+        var profiles = LoadProfiles();
+        profiles.AddOrUpdateConnection(connection);
+        SaveProfiles(profiles);
+    }
+
+    /// <summary>
+    /// Removes a connection profile by name.
+    /// </summary>
+    public bool RemoveConnection(string name)
+    {
+        var profiles = LoadProfiles();
+        var removed = profiles.RemoveConnection(name);
+        if (removed)
+        {
+            SaveProfiles(profiles);
+        }
+        return removed;
+    }
+
+    /// <summary>
+    /// Gets a connection by name.
+    /// </summary>
+    public RemoteConnection? GetConnection(string name)
+    {
+        var profiles = LoadProfiles();
+        return profiles.GetConnection(name);
+    }
+
+    /// <summary>
+    /// Gets the default connection.
+    /// </summary>
+    public RemoteConnection? GetDefaultConnection()
+    {
+        var profiles = LoadProfiles();
+        return profiles.GetDefaultConnection();
+    }
+
+    /// <summary>
+    /// Sets a connection as the default.
+    /// </summary>
+    public void SetDefaultConnection(string name)
+    {
+        var profiles = LoadProfiles();
+
+        // Clear existing default
+        foreach (var conn in profiles.Connections)
+        {
+            conn.IsDefault = false;
+        }
+
+        // Set new default
+        var connection = profiles.GetConnection(name);
+        if (connection != null)
+        {
+            connection.IsDefault = true;
+            SaveProfiles(profiles);
+        }
+    }
+
+    /// <summary>
+    /// Lists all connection profiles.
+    /// </summary>
+    public List<RemoteConnection> ListConnections()
+    {
+        var profiles = LoadProfiles();
+        return profiles.Connections;
+    }
+}

--- a/src/HomeLab.Cli/Services/Remote/SshService.cs
+++ b/src/HomeLab.Cli/Services/Remote/SshService.cs
@@ -1,0 +1,160 @@
+using HomeLab.Cli.Models;
+using Renci.SshNet;
+
+namespace HomeLab.Cli.Services.Remote;
+
+/// <summary>
+/// SSH service implementation using SSH.NET library.
+/// </summary>
+public class SshService : ISshService
+{
+    public async Task<bool> TestConnectionAsync(RemoteConnection connection)
+    {
+        try
+        {
+            using var client = CreateSshClient(connection);
+            await Task.Run(() => client.Connect());
+            var isConnected = client.IsConnected;
+            client.Disconnect();
+            return isConnected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<CommandResult> ExecuteCommandAsync(RemoteConnection connection, string command)
+    {
+        using var client = CreateSshClient(connection);
+
+        await Task.Run(() => client.Connect());
+
+        if (!client.IsConnected)
+        {
+            return new CommandResult
+            {
+                ExitCode = -1,
+                Error = "Failed to connect to remote host"
+            };
+        }
+
+        try
+        {
+            var cmd = client.CreateCommand(command);
+            var result = await Task.Run(() => cmd.Execute());
+
+            return new CommandResult
+            {
+                ExitCode = cmd.ExitStatus ?? -1,
+                Output = result,
+                Error = cmd.Error
+            };
+        }
+        finally
+        {
+            client.Disconnect();
+        }
+    }
+
+    public async Task UploadFileAsync(RemoteConnection connection, string localPath, string remotePath)
+    {
+        using var client = CreateSftpClient(connection);
+
+        await Task.Run(() => client.Connect());
+
+        if (!client.IsConnected)
+        {
+            throw new InvalidOperationException("Failed to connect to remote host");
+        }
+
+        try
+        {
+            using var fileStream = File.OpenRead(localPath);
+            await Task.Run(() => client.UploadFile(fileStream, remotePath, true));
+        }
+        finally
+        {
+            client.Disconnect();
+        }
+    }
+
+    public async Task DownloadFileAsync(RemoteConnection connection, string remotePath, string localPath)
+    {
+        using var client = CreateSftpClient(connection);
+
+        await Task.Run(() => client.Connect());
+
+        if (!client.IsConnected)
+        {
+            throw new InvalidOperationException("Failed to connect to remote host");
+        }
+
+        try
+        {
+            using var fileStream = File.Create(localPath);
+            await Task.Run(() => client.DownloadFile(remotePath, fileStream));
+        }
+        finally
+        {
+            client.Disconnect();
+        }
+    }
+
+    public async Task<bool> IsDockerRunningAsync(RemoteConnection connection)
+    {
+        var result = await ExecuteCommandAsync(connection, "docker info >/dev/null 2>&1 && echo 'running' || echo 'not running'");
+        return result.Success && result.Output.Contains("running");
+    }
+
+    private SshClient CreateSshClient(RemoteConnection connection)
+    {
+        ConnectionInfo connectionInfo;
+
+        if (!string.IsNullOrEmpty(connection.KeyFile))
+        {
+            // Use SSH key authentication
+            var keyFile = new PrivateKeyFile(ExpandPath(connection.KeyFile));
+            var keyAuth = new PrivateKeyAuthenticationMethod(connection.Username, keyFile);
+            connectionInfo = new ConnectionInfo(connection.Host, connection.Port, connection.Username, keyAuth);
+        }
+        else
+        {
+            // Use password authentication (will prompt if needed)
+            // For now, we'll use keyboard-interactive which can handle various auth methods
+            var keyboardAuth = new KeyboardInteractiveAuthenticationMethod(connection.Username);
+            connectionInfo = new ConnectionInfo(connection.Host, connection.Port, connection.Username, keyboardAuth);
+        }
+
+        return new SshClient(connectionInfo);
+    }
+
+    private SftpClient CreateSftpClient(RemoteConnection connection)
+    {
+        ConnectionInfo connectionInfo;
+
+        if (!string.IsNullOrEmpty(connection.KeyFile))
+        {
+            var keyFile = new PrivateKeyFile(ExpandPath(connection.KeyFile));
+            var keyAuth = new PrivateKeyAuthenticationMethod(connection.Username, keyFile);
+            connectionInfo = new ConnectionInfo(connection.Host, connection.Port, connection.Username, keyAuth);
+        }
+        else
+        {
+            var keyboardAuth = new KeyboardInteractiveAuthenticationMethod(connection.Username);
+            connectionInfo = new ConnectionInfo(connection.Host, connection.Port, connection.Username, keyboardAuth);
+        }
+
+        return new SftpClient(connectionInfo);
+    }
+
+    private string ExpandPath(string path)
+    {
+        if (path.StartsWith("~/"))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, path.Substring(2));
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 5, Day 6: Remote Management

This PR adds comprehensive remote homelab management capabilities, enabling CLI management of remote hosts (like Mac Mini) via SSH.

### Remote Connection Management

- **RemoteConnection Model**: Stores connection profiles
  - Name, host, port, username
  - SSH key file path support
  - Docker socket path on remote
  - Compose file path on remote
  - Default connection support
  - Last connected timestamp

- **RemoteConnectionService**: Profile storage
  - Stored in `~/.homelab/remotes.yaml`
  - YamlDotNet serialization
  - Add/update/remove/list connections
  - Get default connection
  - Set default connection

### SSH Service Implementation

- **ISshService Interface**: Defines remote operations
  - Test connection
  - Execute commands
  - Upload files (SFTP)
  - Download files (SFTP)
  - Check Docker status

- **SshService**: SSH.NET implementation
  - SSH key-based authentication
  - Password/keyboard-interactive fallback
  - Command execution with exit code/output/error
  - SFTP file transfer
  - Path expansion (~/ to home directory)

### Remote Commands

#### `homelab remote connect`
- Add or update remote connection profiles
- Test connection before saving
- Check if Docker is running on remote
- Support for SSH keys
- Set as default connection
- Show connection details table

```bash
homelab remote connect mac-mini 192.168.1.100 -u username -k ~/.ssh/id_rsa --default
```

#### `homelab remote list`
- List all configured remote connections
- Show connection details in table format
- Indicate default connection with star ⭐
- Display last connected time (formatted as "5m ago", "2h ago", etc.)

```bash
homelab remote list
```

#### `homelab remote status`
- Check status of remote homelab
- Test SSH connection
- Check Docker status and version
- Show system info (CPUs, memory)
- List running containers
- Uses default connection if name not specified

```bash
homelab remote status mac-mini
homelab remote status  # uses default
```

#### `homelab remote sync`
- Sync docker-compose files between local and remote
- Push local file to remote (`--push`)
- Pull remote file to local (`--pull`)
- Confirmation prompts for overwrites
- File size reporting

```bash
homelab remote sync --push
homelab remote sync --pull --local-file custom-compose.yml
```

#### `homelab remote remove`
- Remove connection profile
- Confirmation prompt (can skip with `-y`)
- Warning if removing default connection

```bash
homelab remote remove mac-mini
homelab remote remove mac-mini -y  # skip confirmation
```

### Technical Implementation

- **SSH.NET Library**: Robust SSH/SFTP client
  - Connection testing
  - Command execution
  - File transfer
  - Multiple authentication methods

- **Profile Storage**: YamlDotNet
  - Human-readable YAML format
  - Stored in ~/.homelab/ directory
  - Automatic directory creation

- **Error Handling**:
  - Connection failures gracefully handled
  - Clear error messages
  - Validation of required parameters

- **User Experience**:
  - Beautiful Figlet headers
  - Status spinners for operations
  - Color-coded output
  - Formatted tables
  - Time-ago formatting

### Files Changed

**New Files (9)**:
- `Models/RemoteConnection.cs` - Connection profile models
- `Services/Remote/ISshService.cs` - SSH service interface
- `Services/Remote/SshService.cs` - SSH.NET implementation
- `Services/Remote/RemoteConnectionService.cs` - Profile management
- `Commands/Remote/RemoteConnectCommand.cs`
- `Commands/Remote/RemoteListCommand.cs`
- `Commands/Remote/RemoteStatusCommand.cs`
- `Commands/Remote/RemoteSyncCommand.cs`
- `Commands/Remote/RemoteRemoveCommand.cs`

**Modified Files (1)**:
- `Program.cs` - Registered remote branch commands

### Testing

✅ Build successful (`dotnet build`)
✅ Remote commands registered correctly
✅ Help text displays properly
✅ Remote list works with no connections
✅ Connection profiles structure ready

### Example Usage Flow

```bash
# Add a remote connection
homelab remote connect mac-mini 192.168.1.100 -u admin -k ~/.ssh/id_rsa --default

# List connections
homelab remote list

# Check remote status
homelab remote status

# Sync compose file to remote
homelab remote sync --push

# Remove connection
homelab remote remove old-server
```

### Next Steps

Day 7 will implement:
- Polish and testing
- Unit tests for all services
- Integration tests
- Documentation updates
- v1.5.0 release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)