### PR TITLE
feat: Phase 10 - Self-Update Command + Uptime Remove

### DIFF
--- a/src/HomeLab.Cli/Commands/ImageUpdateCommand.cs
+++ b/src/HomeLab.Cli/Commands/ImageUpdateCommand.cs
@@ -7,9 +7,9 @@ namespace HomeLab.Cli.Commands;
 
 /// <summary>
 /// Updates container images.
-/// Usage: homelab update <image>
+/// Usage: homelab image-update <image>
 /// </summary>
-public class UpdateCommand : AsyncCommand<UpdateCommand.Settings>
+public class ImageUpdateCommand : AsyncCommand<ImageUpdateCommand.Settings>
 {
     public class Settings : CommandSettings
     {
@@ -20,7 +20,7 @@ public class UpdateCommand : AsyncCommand<UpdateCommand.Settings>
 
     private readonly IDockerService _dockerService;
 
-    public UpdateCommand(IDockerService dockerService)
+    public ImageUpdateCommand(IDockerService dockerService)
     {
         _dockerService = dockerService;
     }

--- a/src/HomeLab.Cli/Commands/SelfUpdateCommand.cs
+++ b/src/HomeLab.Cli/Commands/SelfUpdateCommand.cs
@@ -1,0 +1,265 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using HomeLab.Cli.Services.Update;
+
+namespace HomeLab.Cli.Commands;
+
+/// <summary>
+/// Update the HomeLab CLI to the latest version from GitHub releases.
+/// </summary>
+public class SelfUpdateCommand : AsyncCommand<SelfUpdateCommand.Settings>
+{
+    private readonly IGitHubReleaseService _releaseService;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--check")]
+        [Description("Check for updates without installing")]
+        public bool CheckOnly { get; set; }
+
+        [CommandOption("--version <VERSION>")]
+        [Description("Install a specific version (e.g., v1.6.0 or 1.6.0)")]
+        public string? TargetVersion { get; set; }
+
+        [CommandOption("--force")]
+        [Description("Skip confirmation prompt")]
+        public bool Force { get; set; }
+    }
+
+    public SelfUpdateCommand(IGitHubReleaseService releaseService)
+    {
+        _releaseService = releaseService;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Self Update")
+                .Centered()
+                .Color(Color.Cyan));
+
+        AnsiConsole.WriteLine();
+
+        // Get current version
+        var currentVersion = GetCurrentVersion();
+        AnsiConsole.MarkupLine($"[yellow]Current version:[/] [cyan]{currentVersion}[/]\n");
+
+        // Fetch release information
+        GitHubRelease? release = null;
+
+        await AnsiConsole.Status()
+            .StartAsync("Checking for updates...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+
+                if (!string.IsNullOrEmpty(settings.TargetVersion))
+                {
+                    release = await _releaseService.GetReleaseByTagAsync(settings.TargetVersion);
+                }
+                else
+                {
+                    release = await _releaseService.GetLatestReleaseAsync();
+                }
+            });
+
+        if (release == null)
+        {
+            AnsiConsole.MarkupLine("[red]✗ Failed to fetch release information from GitHub[/]");
+            AnsiConsole.MarkupLine("[yellow]Please check your internet connection and try again[/]");
+            return 1;
+        }
+
+        // Display release information
+        var releaseVersion = release.TagName.TrimStart('v');
+        var versionComparison = _releaseService.CompareVersions(releaseVersion, currentVersion);
+
+        AnsiConsole.MarkupLine($"[yellow]Latest version:[/] [green]{release.TagName}[/]");
+        AnsiConsole.MarkupLine($"[yellow]Released:[/] [dim]{release.PublishedAt:yyyy-MM-dd}[/]\n");
+
+        if (versionComparison == 0)
+        {
+            AnsiConsole.MarkupLine("[green]✓ You are already running the latest version![/]");
+            return 0;
+        }
+        else if (versionComparison < 0 && string.IsNullOrEmpty(settings.TargetVersion))
+        {
+            AnsiConsole.MarkupLine("[yellow]⚠ You are running a newer version than the latest release[/]");
+            AnsiConsole.MarkupLine("[dim]This might be a pre-release or development version[/]");
+            return 0;
+        }
+
+        // Show release notes
+        if (!string.IsNullOrEmpty(release.Body))
+        {
+            var releaseNotes = new Panel(release.Body.Length > 500
+                ? release.Body.Substring(0, 500) + "..."
+                : release.Body)
+                .Header($"[cyan]Release Notes - {release.TagName}[/]")
+                .BorderColor(Color.Cyan)
+                .RoundedBorder();
+
+            AnsiConsole.Write(releaseNotes);
+            AnsiConsole.WriteLine();
+        }
+
+        // If check-only mode, exit here
+        if (settings.CheckOnly)
+        {
+            if (versionComparison > 0)
+            {
+                AnsiConsole.MarkupLine($"[green]✓ Update available: {currentVersion} → {release.TagName}[/]");
+                AnsiConsole.MarkupLine("[dim]Run 'homelab self-update' to install[/]");
+            }
+            return 0;
+        }
+
+        // Find the correct binary asset for this platform
+        var binaryName = "HomeLab.Cli"; // The asset name in GitHub releases
+        var asset = release.Assets.FirstOrDefault(a =>
+            a.Name.Equals(binaryName, StringComparison.OrdinalIgnoreCase) ||
+            a.Name.Equals("homelab", StringComparison.OrdinalIgnoreCase));
+
+        if (asset == null)
+        {
+            AnsiConsole.MarkupLine($"[red]✗ No compatible binary found for this platform[/]");
+            AnsiConsole.MarkupLine($"[yellow]Release URL:[/] {release.HtmlUrl}");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine($"[yellow]Binary:[/] {asset.Name} ({FormatBytes(asset.Size)})");
+        AnsiConsole.WriteLine();
+
+        // Confirm installation
+        if (!settings.Force)
+        {
+            var confirm = AnsiConsole.Confirm(
+                $"[cyan]Install version {release.TagName}?[/]",
+                false);
+
+            if (!confirm)
+            {
+                AnsiConsole.MarkupLine("[yellow]Update cancelled[/]");
+                return 0;
+            }
+        }
+
+        // Download and install
+        return await DownloadAndInstall(asset, release.TagName);
+    }
+
+    private async Task<int> DownloadAndInstall(GitHubAsset asset, string version)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"homelab-{version}");
+        var installPath = "/usr/local/bin/homelab";
+
+        try
+        {
+            // Download
+            var downloadSuccess = await AnsiConsole.Status()
+                .StartAsync("Downloading update...", async ctx =>
+                {
+                    ctx.Spinner(Spinner.Known.Dots);
+                    return await _releaseService.DownloadAssetAsync(asset, tempPath);
+                });
+
+            if (!downloadSuccess)
+            {
+                AnsiConsole.MarkupLine("[red]✗ Failed to download binary[/]");
+                return 1;
+            }
+
+            AnsiConsole.MarkupLine("[green]✓ Download complete[/]");
+
+            // Make executable
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                var chmodProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "chmod",
+                    Arguments = $"+x {tempPath}",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                });
+
+                if (chmodProcess != null)
+                {
+                    await chmodProcess.WaitForExitAsync();
+                }
+            }
+
+            // Replace binary (requires sudo)
+            AnsiConsole.MarkupLine("\n[yellow]Installing update (requires sudo)...[/]");
+
+            var cpProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "sudo",
+                Arguments = $"cp {tempPath} {installPath}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            });
+
+            if (cpProcess == null)
+            {
+                AnsiConsole.MarkupLine("[red]✗ Failed to start installation process[/]");
+                return 1;
+            }
+
+            await cpProcess.WaitForExitAsync();
+
+            if (cpProcess.ExitCode != 0)
+            {
+                AnsiConsole.MarkupLine("[red]✗ Installation failed[/]");
+                AnsiConsole.MarkupLine("[yellow]You may need to manually copy the binary:[/]");
+                AnsiConsole.MarkupLine($"[dim]sudo cp {tempPath} {installPath}[/]");
+                return 1;
+            }
+
+            // Clean up temp file
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+
+            AnsiConsole.MarkupLine($"[green]✓ Successfully updated to version {version}![/]");
+            AnsiConsole.MarkupLine("\n[dim]Run 'homelab version' to verify the installation[/]");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]✗ Update failed: {ex.Message}[/]");
+            return 1;
+        }
+    }
+
+    private string GetCurrentVersion()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var version = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion ?? "Unknown";
+
+        return version.TrimStart('v');
+    }
+
+    private string FormatBytes(long bytes)
+    {
+        string[] sizes = { "B", "KB", "MB", "GB" };
+        double len = bytes;
+        int order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len = len / 1024;
+        }
+        return $"{len:0.##} {sizes[order]}";
+    }
+}

--- a/src/HomeLab.Cli/Commands/Uptime/UptimeRemoveCommand.cs
+++ b/src/HomeLab.Cli/Commands/Uptime/UptimeRemoveCommand.cs
@@ -1,0 +1,124 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using HomeLab.Cli.Services.UptimeKuma;
+using HomeLab.Cli.Services.Abstractions;
+using System.ComponentModel;
+
+namespace HomeLab.Cli.Commands.Uptime;
+
+/// <summary>
+/// Remove a monitor from uptime tracking.
+/// </summary>
+public class UptimeRemoveCommand : AsyncCommand<UptimeRemoveCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+
+    public UptimeRemoveCommand(IServiceClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<ID>")]
+        [Description("Monitor ID to remove")]
+        public int MonitorId { get; set; }
+
+        [CommandOption("--force")]
+        [Description("Skip confirmation prompt")]
+        public bool Force { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var client = _clientFactory.CreateUptimeKumaClient();
+
+        // Get monitor details first
+        UptimeMonitor? monitor = null;
+
+        await AnsiConsole.Status()
+            .StartAsync("Fetching monitor details...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                monitor = await client.GetMonitorAsync(settings.MonitorId);
+            });
+
+        if (monitor == null)
+        {
+            // If we can't get the monitor, show all monitors to help user
+            var allMonitors = await client.GetMonitorsAsync();
+
+            if (allMonitors.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]No monitors found.[/]");
+                return 1;
+            }
+
+            AnsiConsole.MarkupLine($"[red]✗ Monitor ID {settings.MonitorId} not found.[/]\n");
+            AnsiConsole.MarkupLine("[yellow]Available monitors:[/]");
+
+            var table = new Table();
+            table.Border(TableBorder.Rounded);
+            table.AddColumn("[yellow]ID[/]");
+            table.AddColumn("[yellow]Name[/]");
+            table.AddColumn("[yellow]URL[/]");
+
+            foreach (var m in allMonitors)
+            {
+                table.AddRow(m.Id.ToString(), m.Name, $"[dim]{m.Url}[/]");
+            }
+
+            AnsiConsole.Write(table);
+            return 1;
+        }
+
+        // Show what will be removed
+        AnsiConsole.WriteLine();
+        var infoPanel = new Panel(
+            new Markup($"[yellow]ID:[/] {monitor.Id}\n" +
+                      $"[yellow]Name:[/] {monitor.Name}\n" +
+                      $"[yellow]URL:[/] {monitor.Url}\n" +
+                      $"[yellow]Type:[/] {monitor.Type}"))
+            .Header("[red]Monitor to Remove[/]")
+            .BorderColor(Color.Red)
+            .RoundedBorder();
+
+        AnsiConsole.Write(infoPanel);
+        AnsiConsole.WriteLine();
+
+        // Confirm removal unless --force is used
+        if (!settings.Force)
+        {
+            var confirm = AnsiConsole.Confirm(
+                $"[red]Are you sure you want to remove monitor '{monitor.Name}'?[/]",
+                false);
+
+            if (!confirm)
+            {
+                AnsiConsole.MarkupLine("[yellow]Cancelled.[/]");
+                return 0;
+            }
+        }
+
+        // Remove monitor
+        var success = await AnsiConsole.Status()
+            .StartAsync("Removing monitor from Uptime Kuma...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                return await client.RemoveMonitorAsync(settings.MonitorId);
+            });
+
+        if (success)
+        {
+            AnsiConsole.MarkupLine($"[green]✓ Successfully removed monitor '{monitor.Name}'[/]");
+            AnsiConsole.MarkupLine("[dim]Use 'homelab uptime status' to view remaining monitors[/]");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]✗ Failed to remove monitor '{monitor.Name}'[/]");
+            AnsiConsole.MarkupLine("[yellow]Tip: Check if Uptime Kuma is running and accessible[/]");
+            return 1;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/VersionCommand.cs
+++ b/src/HomeLab.Cli/Commands/VersionCommand.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands;
+
+/// <summary>
+/// Display the current version of the HomeLab CLI.
+/// </summary>
+public class VersionCommand : Command<VersionCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+    }
+
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var version = assembly.GetName().Version;
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion ?? version?.ToString() ?? "Unknown";
+
+        var productName = assembly
+            .GetCustomAttribute<AssemblyProductAttribute>()?
+            .Product ?? "HomeLab CLI";
+
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+
+        grid.AddRow(
+            new Markup("[yellow]Product:[/]"),
+            new Markup($"[cyan]{productName}[/]")
+        );
+        grid.AddRow(
+            new Markup("[yellow]Version:[/]"),
+            new Markup($"[green]{informationalVersion}[/]")
+        );
+        grid.AddRow(
+            new Markup("[yellow]Runtime:[/]"),
+            new Markup($"[dim].NET {Environment.Version}[/]")
+        );
+        grid.AddRow(
+            new Markup("[yellow]Platform:[/]"),
+            new Markup($"[dim]{Environment.OSVersion.Platform} ({RuntimeInformation.OSArchitecture})[/]")
+        );
+
+        AnsiConsole.Write(
+            new Panel(grid)
+                .Header("[green]Version Information[/]")
+                .BorderColor(Color.Green)
+                .RoundedBorder()
+        );
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[dim]Run 'homelab self-update --check' to check for updates[/]");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/HomeLab.Cli.csproj
+++ b/src/HomeLab.Cli/HomeLab.Cli.csproj
@@ -5,6 +5,15 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- Version Information -->
+    <Version>1.6.0</Version>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <FileVersion>1.6.0.0</FileVersion>
+    <InformationalVersion>1.6.0</InformationalVersion>
+    <Product>HomeLab CLI</Product>
+    <Authors>HomeLab Team</Authors>
+    <Description>Command-line tool for managing Mac Mini M4 homelab services</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -15,6 +15,7 @@ using HomeLab.Cli.Services.Health;
 using HomeLab.Cli.Services.Abstractions;
 using HomeLab.Cli.Services.ServiceDiscovery;
 using HomeLab.Cli.Services.Output;
+using HomeLab.Cli.Services.Update;
 
 namespace HomeLab.Cli;
 
@@ -46,6 +47,9 @@ public static class Program
         // Phase 6: Output formatting
         services.AddSingleton<IOutputFormatter, OutputFormatter>();
 
+        // Phase 10: Self-update service
+        services.AddSingleton<IGitHubReleaseService, GitHubReleaseService>();
+
         // Create registrar to connect Spectre with DI
         var registrar = new TypeRegistrar(services);
 
@@ -71,11 +75,18 @@ public static class Program
             config.AddCommand<LogsCommand>("logs")
                 .WithDescription("View container logs");
 
-            config.AddCommand<UpdateCommand>("update")
+            config.AddCommand<ImageUpdateCommand>("image-update")
                 .WithDescription("Update container images");
 
             config.AddCommand<CleanupCommand>("cleanup")
                 .WithDescription("Clean up unused Docker resources");
+
+            // Phase 10: Version and self-update commands
+            config.AddCommand<VersionCommand>("version")
+                .WithDescription("Display version information");
+
+            config.AddCommand<SelfUpdateCommand>("self-update")
+                .WithDescription("Update HomeLab CLI to the latest version");
 
             config.AddCommand<TuiCommand>("tui")
                 .WithAlias("ui")
@@ -156,6 +167,9 @@ public static class Program
                     .WithDescription("Show recent uptime alerts and incidents");
                 uptime.AddCommand<UptimeAddCommand>("add")
                     .WithDescription("Add a new service to monitor");
+                uptime.AddCommand<UptimeRemoveCommand>("remove")
+                    .WithAlias("rm")
+                    .WithDescription("Remove a monitor from tracking");
             });
 
             // Phase 6: Internet Speed Testing

--- a/src/HomeLab.Cli/Services/Update/GitHubRelease.cs
+++ b/src/HomeLab.Cli/Services/Update/GitHubRelease.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace HomeLab.Cli.Services.Update;
+
+/// <summary>
+/// Represents a GitHub release.
+/// </summary>
+public class GitHubRelease
+{
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [JsonPropertyName("draft")]
+    public bool Draft { get; set; }
+
+    [JsonPropertyName("prerelease")]
+    public bool Prerelease { get; set; }
+
+    [JsonPropertyName("published_at")]
+    public DateTime PublishedAt { get; set; }
+
+    [JsonPropertyName("assets")]
+    public List<GitHubAsset> Assets { get; set; } = new();
+
+    [JsonPropertyName("html_url")]
+    public string HtmlUrl { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Represents a GitHub release asset (downloadable file).
+/// </summary>
+public class GitHubAsset
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("browser_download_url")]
+    public string BrowserDownloadUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("content_type")]
+    public string ContentType { get; set; } = string.Empty;
+}

--- a/src/HomeLab.Cli/Services/Update/GitHubReleaseService.cs
+++ b/src/HomeLab.Cli/Services/Update/GitHubReleaseService.cs
@@ -1,0 +1,95 @@
+using System.Net.Http.Json;
+
+namespace HomeLab.Cli.Services.Update;
+
+/// <summary>
+/// Implementation of GitHub Release service for checking updates.
+/// </summary>
+public class GitHubReleaseService : IGitHubReleaseService
+{
+    private readonly HttpClient _httpClient;
+    private const string GitHubApiBase = "https://api.github.com";
+    private const string RepoOwner = "moudlajs";
+    private const string RepoName = "homelab";
+
+    public GitHubReleaseService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+
+        // GitHub API requires User-Agent header
+        if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
+        {
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "HomeLab-CLI");
+        }
+    }
+
+    public async Task<GitHubRelease?> GetLatestReleaseAsync()
+    {
+        try
+        {
+            var url = $"{GitHubApiBase}/repos/{RepoOwner}/{RepoName}/releases/latest";
+            var release = await _httpClient.GetFromJsonAsync<GitHubRelease>(url);
+            return release;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public async Task<GitHubRelease?> GetReleaseByTagAsync(string tag)
+    {
+        try
+        {
+            // Ensure tag starts with 'v'
+            if (!tag.StartsWith('v'))
+            {
+                tag = $"v{tag}";
+            }
+
+            var url = $"{GitHubApiBase}/repos/{RepoOwner}/{RepoName}/releases/tags/{tag}";
+            var release = await _httpClient.GetFromJsonAsync<GitHubRelease>(url);
+            return release;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> DownloadAssetAsync(GitHubAsset asset, string destinationPath)
+    {
+        try
+        {
+            // Download the file
+            var response = await _httpClient.GetAsync(asset.BrowserDownloadUrl);
+            response.EnsureSuccessStatusCode();
+
+            // Write to destination
+            await using var fileStream = File.Create(destinationPath);
+            await response.Content.CopyToAsync(fileStream);
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public int CompareVersions(string v1, string v2)
+    {
+        // Remove 'v' prefix if present
+        v1 = v1.TrimStart('v');
+        v2 = v2.TrimStart('v');
+
+        // Try to parse as Version objects
+        if (Version.TryParse(v1, out var version1) && Version.TryParse(v2, out var version2))
+        {
+            return version1.CompareTo(version2);
+        }
+
+        // Fall back to string comparison
+        return string.Compare(v1, v2, StringComparison.Ordinal);
+    }
+}

--- a/src/HomeLab.Cli/Services/Update/IGitHubReleaseService.cs
+++ b/src/HomeLab.Cli/Services/Update/IGitHubReleaseService.cs
@@ -1,0 +1,30 @@
+namespace HomeLab.Cli.Services.Update;
+
+/// <summary>
+/// Service for interacting with GitHub Releases API to check for updates.
+/// </summary>
+public interface IGitHubReleaseService
+{
+    /// <summary>
+    /// Get the latest release from GitHub.
+    /// </summary>
+    Task<GitHubRelease?> GetLatestReleaseAsync();
+
+    /// <summary>
+    /// Get a specific release by tag name (e.g., "v1.6.0").
+    /// </summary>
+    Task<GitHubRelease?> GetReleaseByTagAsync(string tag);
+
+    /// <summary>
+    /// Download a release asset (binary file) to the specified path.
+    /// </summary>
+    Task<bool> DownloadAssetAsync(GitHubAsset asset, string destinationPath);
+
+    /// <summary>
+    /// Compare two version strings. Returns:
+    /// - Negative if v1 &lt; v2
+    /// - Zero if v1 == v2
+    /// - Positive if v1 &gt; v2
+    /// </summary>
+    int CompareVersions(string v1, string v2);
+}


### PR DESCRIPTION
## Phase 10: Self-Update Command ✅

Implements self-updating functionality allowing the CLI to update itself from GitHub releases.

### What's New

**Commands:**
- `homelab version` - Display version information
- `homelab self-update` - Update to latest GitHub release  
- `homelab self-update --check` - Check for updates without installing
- `homelab self-update --version v1.x.x` - Install specific version
- `homelab self-update --force` - Skip confirmation

**Phase 9a Completion:**
- `homelab uptime rm <id>` - Remove uptime monitor

### Implementation Details

**Services:**
- `IGitHubReleaseService` - Interface for GitHub API
- `GitHubReleaseService` - Fetches releases, downloads binaries, compares versions
- `GitHubRelease` & `GitHubAsset` - Models for GitHub API responses

**Commands:**
- `VersionCommand` - Shows product, version, runtime, platform info
- `SelfUpdateCommand` - Downloads and installs updates from GitHub
- `UptimeRemoveCommand` - Removes monitors from Uptime Kuma

**Breaking Changes:**
- ⚠️ `homelab update` renamed to `homelab image-update` (for Docker images)

### Version Info

Updated project to v1.6.0 with full assembly metadata:
- Version: 1.6.0
- Product: HomeLab CLI
- Description: Command-line tool for managing Mac Mini M4 homelab services

### Testing

\`\`\`bash
# Display version
homelab version

# Check for updates
homelab self-update --check

# Update to latest (when v1.6.0 is released)
homelab self-update

# Update to specific version
homelab self-update --version v1.5.0
\`\`\`

### Architecture

- Uses GitHub API: \`https://api.github.com/repos/moudlajs/homelab/releases\`
- Downloads binary from release assets
- Requires sudo to replace \`/usr/local/bin/homelab\`
- Cross-platform version comparison (semantic versioning)

### Next Steps

After merging:
1. Create GitHub release v1.6.0
2. Attach binary (HomeLab.Cli)
3. Test self-update from v1.5.0 → v1.6.0

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)