### PR TITLE
feat: GitHub Token Auth for Self-Update (Private Repos)

### DIFF
--- a/config/homelab-cli.yaml.example
+++ b/config/homelab-cli.yaml.example
@@ -30,3 +30,10 @@ remote:
     user: "your-username"   # Update with your username
     docker_host: "unix:///var/run/docker.sock"
     compose_file: "/path/to/mac-mini/docker-compose.yml"
+
+# GitHub configuration for self-update (required for private repos)
+github:
+  # Personal access token with 'repo' scope
+  # Generate at: https://github.com/settings/tokens/new
+  # Required scopes: repo (for private repos) or public_repo (for public repos)
+  token: ""  # Add your token here

--- a/src/HomeLab.Cli/Services/Configuration/HomelabConfigService.cs
+++ b/src/HomeLab.Cli/Services/Configuration/HomelabConfigService.cs
@@ -110,4 +110,10 @@ public class HomelabConfigService : IHomelabConfigService
 
         return config;
     }
+
+    public string? GetGitHubToken()
+    {
+        _config ??= LoadConfigAsync().GetAwaiter().GetResult();
+        return _config.GitHub?.Token;
+    }
 }

--- a/src/HomeLab.Cli/Services/Configuration/IHomelabConfigService.cs
+++ b/src/HomeLab.Cli/Services/Configuration/IHomelabConfigService.cs
@@ -35,6 +35,11 @@ public interface IHomelabConfigService
     /// Gets Home Assistant configuration (URL defaults to http://localhost:8123).
     /// </summary>
     ServiceConfig GetHomeAssistantConfig();
+
+    /// <summary>
+    /// Gets GitHub personal access token for self-update (required for private repos).
+    /// </summary>
+    string? GetGitHubToken();
 }
 
 /// <summary>
@@ -45,6 +50,7 @@ public class HomelabConfig
     public DevelopmentConfig Development { get; set; } = new();
     public Dictionary<string, ServiceConfig> Services { get; set; } = new();
     public RemoteConfig Remote { get; set; } = new();
+    public GitHubConfig? GitHub { get; set; }
 }
 
 /// <summary>
@@ -87,4 +93,12 @@ public class RemoteHostConfig
     public string User { get; set; } = string.Empty;
     public string DockerHost { get; set; } = "unix:///var/run/docker.sock";
     public string ComposeFile { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// GitHub configuration for self-update.
+/// </summary>
+public class GitHubConfig
+{
+    public string? Token { get; set; }
 }

--- a/src/HomeLab.Cli/Services/Update/GitHubReleaseService.cs
+++ b/src/HomeLab.Cli/Services/Update/GitHubReleaseService.cs
@@ -1,25 +1,36 @@
 using System.Net.Http.Json;
+using HomeLab.Cli.Services.Configuration;
 
 namespace HomeLab.Cli.Services.Update;
 
 /// <summary>
 /// Implementation of GitHub Release service for checking updates.
+/// Supports authentication for private repositories via personal access token.
 /// </summary>
 public class GitHubReleaseService : IGitHubReleaseService
 {
     private readonly HttpClient _httpClient;
+    private readonly IHomelabConfigService _configService;
     private const string GitHubApiBase = "https://api.github.com";
     private const string RepoOwner = "moudlajs";
     private const string RepoName = "homelab";
 
-    public GitHubReleaseService(HttpClient httpClient)
+    public GitHubReleaseService(HttpClient httpClient, IHomelabConfigService configService)
     {
         _httpClient = httpClient;
+        _configService = configService;
 
         // GitHub API requires User-Agent header
         if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
         {
             _httpClient.DefaultRequestHeaders.Add("User-Agent", "HomeLab-CLI");
+        }
+
+        // Add authorization header if token is configured (required for private repos)
+        var token = _configService.GetGitHubToken();
+        if (!string.IsNullOrEmpty(token) && !_httpClient.DefaultRequestHeaders.Contains("Authorization"))
+        {
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"token {token}");
         }
     }
 


### PR DESCRIPTION
## GitHub Token Authentication for Self-Update

Enables \`homelab self-update\` to work with private repositories using GitHub personal access tokens.

### Problem
- Repository is private
- GitHub API returns 404 without authentication
- Self-update command was non-functional

### Solution
- Add \`github.token\` config to \`homelab-cli.yaml\`
- Update \`GitHubReleaseService\` to use token from config
- Token added to Authorization header: \`Authorization: token ghp_xxx\`

### Changes
- ✅ Add \`GitHubConfig\` class with \`Token\` property
- ✅ Add \`IHomelabConfigService.GetGitHubToken()\` method
- ✅ Update \`GitHubReleaseService\` constructor to inject config and use token
- ✅ Update example config with GitHub section and instructions

### Configuration

**config/homelab-cli.yaml:**
\`\`\`yaml
github:
  token: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
\`\`\`

**Generate token:**
1. Visit: https://github.com/settings/tokens/new
2. Select scope: \`repo\` (for private repos)
3. Copy token and add to config

### Testing
\`\`\`bash
# Check for updates
homelab self-update --check

# Install update
homelab self-update
\`\`\`

### Security
- Token stored locally in \`config/homelab-cli.yaml\`
- Config file NOT tracked by git (user-specific)
- Example file includes template without actual token
- Users can revoke token anytime

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)