### PR TITLE
fix: resolve self-update bugs (DI resolution and config loading)

### DIFF
--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -233,13 +233,19 @@ public sealed class TypeRegistrar : ITypeRegistrar
         => _services = services;
 
     public void Register(Type service, Type implementation)
-        => _services.AddSingleton(service, implementation);
+    {
+        _services.AddSingleton(service, implementation);
+    }
 
     public void RegisterInstance(Type service, object implementation)
-        => _services.AddSingleton(service, implementation);
+    {
+        _services.AddSingleton(service, implementation);
+    }
 
     public void RegisterLazy(Type service, Func<object> factory)
-        => _services.AddSingleton(service, _ => factory());
+    {
+        _services.AddSingleton(service, _ => factory());
+    }
 
     public ITypeResolver Build()
         => new TypeResolver(_services.BuildServiceProvider());

--- a/src/HomeLab.Cli/Services/Configuration/HomelabConfigService.cs
+++ b/src/HomeLab.Cli/Services/Configuration/HomelabConfigService.cs
@@ -13,12 +13,16 @@ public class HomelabConfigService : IHomelabConfigService
 
     public HomelabConfigService()
     {
-        // Config file location: config/homelab-cli.yaml relative to repo root
-        _configPath = Path.Combine(
-            Directory.GetCurrentDirectory(),
-            "config",
-            "homelab-cli.yaml"
-        );
+        // Config file location: Try multiple locations in priority order
+        // 1. ~/.config/homelab/homelab-cli.yaml (standard Linux/Mac location)
+        // 2. ./config/homelab-cli.yaml (repo root, for development)
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var userConfigPath = Path.Combine(home, ".config", "homelab", "homelab-cli.yaml");
+        var repoConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config", "homelab-cli.yaml");
+
+        // Use user config if it exists, otherwise fall back to repo config
+        _configPath = File.Exists(userConfigPath) ? userConfigPath : repoConfigPath;
     }
 
     public async Task<HomelabConfig> LoadConfigAsync()
@@ -114,6 +118,6 @@ public class HomelabConfigService : IHomelabConfigService
     public string? GetGitHubToken()
     {
         _config ??= LoadConfigAsync().GetAwaiter().GetResult();
-        return _config.GitHub?.Token;
+        return _config.Github?.Token;
     }
 }

--- a/src/HomeLab.Cli/Services/Configuration/IHomelabConfigService.cs
+++ b/src/HomeLab.Cli/Services/Configuration/IHomelabConfigService.cs
@@ -50,7 +50,7 @@ public class HomelabConfig
     public DevelopmentConfig Development { get; set; } = new();
     public Dictionary<string, ServiceConfig> Services { get; set; } = new();
     public RemoteConfig Remote { get; set; } = new();
-    public GitHubConfig? GitHub { get; set; }
+    public GitHubConfig? Github { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
Fixed two critical bugs preventing the `self-update` command from working:

- **DI Resolution Error**: Fixed YAML property name mismatch causing `GitHubReleaseService` construction to fail
- **Config Loading**: Updated config path to use standard user config location (`~/.config/homelab/`)

## Root Cause
The "Could not resolve type 'SelfUpdateCommand'" error was caused by an exception during dependency injection when `GitHubReleaseService` constructor called `GetGitHubToken()`, which triggered config loading that failed due to property name mismatch.

## Changes
1. Changed `GitHub` → `Github` in `HomelabConfig` to match YamlDotNet's `UnderscoredNamingConvention` (expects `github` in YAML to map to `Github` in C#)
2. Updated `HomelabConfigService` constructor to check `~/.config/homelab/homelab-cli.yaml` first, falling back to repo config
3. Cleaned up `TypeRegistrar` code style (expression-bodied → block-bodied members)

## Testing
✅ `homelab self-update --check` - Successfully fetches latest release from private GitHub repo  
✅ Config loaded from `~/.config/homelab/homelab-cli.yaml`  
✅ GitHub token authentication working  
✅ All other commands continue to work (`version`, `uptime`, etc.)

## Test plan
- [x] Verify `self-update --check` works without errors
- [x] Confirm GitHub API authentication with private repo
- [x] Test config loading from user config directory
- [ ] Test single-file published binary (pending release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)