### PR TITLE
feat: add Traefik services and middlewares commands with export

### DIFF
--- a/src/HomeLab.Cli/Commands/Traefik/TraefikMiddlewaresCommand.cs
+++ b/src/HomeLab.Cli/Commands/Traefik/TraefikMiddlewaresCommand.cs
@@ -1,0 +1,81 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.Output;
+using System.ComponentModel;
+
+namespace HomeLab.Cli.Commands.Traefik;
+
+/// <summary>
+/// Displays all Traefik middlewares.
+/// </summary>
+public class TraefikMiddlewaresCommand : AsyncCommand<TraefikMiddlewaresCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public TraefikMiddlewaresCommand(IServiceClientFactory clientFactory, IOutputFormatter formatter)
+    {
+        _clientFactory = clientFactory;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Traefik Middlewares")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        var client = _clientFactory.CreateTraefikClient();
+        var middlewares = await client.GetMiddlewaresAsync();
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, middlewares))
+            return 0;
+
+        // Display as table (default)
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(Color.Blue);
+
+        table.AddColumn("[yellow]Middleware[/]");
+        table.AddColumn("[yellow]Type[/]");
+        table.AddColumn("[yellow]Status[/]");
+        table.AddColumn("[yellow]Configuration[/]");
+
+        foreach (var middleware in middlewares)
+        {
+            var statusColor = middleware.Status == "enabled" ? "green" : "red";
+            var configList = middleware.Config.Any()
+                ? string.Join("\n", middleware.Config.Select(kv => $"{kv.Key}: {kv.Value}"))
+                : "[dim]none[/]";
+
+            table.AddRow(
+                middleware.Name,
+                middleware.Type,
+                $"[{statusColor}]{middleware.Status}[/]",
+                $"[dim]{configList}[/]"
+            );
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[dim]Total middlewares: {middlewares.Count}[/]");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Commands/Traefik/TraefikServicesCommand.cs
+++ b/src/HomeLab.Cli/Commands/Traefik/TraefikServicesCommand.cs
@@ -1,0 +1,83 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.Output;
+using System.ComponentModel;
+
+namespace HomeLab.Cli.Commands.Traefik;
+
+/// <summary>
+/// Displays all Traefik backend services.
+/// </summary>
+public class TraefikServicesCommand : AsyncCommand<TraefikServicesCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public TraefikServicesCommand(IServiceClientFactory clientFactory, IOutputFormatter formatter)
+    {
+        _clientFactory = clientFactory;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Traefik Services")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        var client = _clientFactory.CreateTraefikClient();
+        var services = await client.GetServicesAsync();
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, services))
+            return 0;
+
+        // Display as table (default)
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(Color.Blue);
+
+        table.AddColumn("[yellow]Service[/]");
+        table.AddColumn("[yellow]Type[/]");
+        table.AddColumn("[yellow]Servers[/]");
+        table.AddColumn("[yellow]Load Balancer[/]");
+        table.AddColumn("[yellow]Status[/]");
+
+        foreach (var service in services)
+        {
+            var statusColor = service.Status == "healthy" ? "green" : "red";
+            var serversList = service.Servers.Any()
+                ? string.Join("\n", service.Servers)
+                : "[dim]none[/]";
+
+            table.AddRow(
+                service.Name,
+                service.Type,
+                $"[dim]{serversList}[/]",
+                service.LoadBalancer,
+                $"[{statusColor}]{service.Status}[/]"
+            );
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[dim]Total services: {services.Count}[/]");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -209,6 +209,11 @@ public static class Program
                     .WithDescription("Display Traefik overview and status");
                 traefik.AddCommand<TraefikRoutesCommand>("routes")
                     .WithDescription("List all HTTP routers");
+                traefik.AddCommand<TraefikServicesCommand>("services")
+                    .WithDescription("List all backend services");
+                traefik.AddCommand<TraefikMiddlewaresCommand>("middlewares")
+                    .WithAlias("mw")
+                    .WithDescription("List all middlewares");
             });
 
             // Phase 7: Quick Actions - Fast operations for daily use


### PR DESCRIPTION
## Summary
Extended Traefik integration with services and middlewares commands, plus full export support.

## New Commands 🚀
```bash
homelab traefik services      # List backend services
homelab traefik middlewares   # List middlewares (alias: mw)
```

## Export Support 📊
All Traefik commands now support universal export:
- `--output json` - JSON format
- `--output csv` - CSV spreadsheet  
- `--output yaml` - YAML format
- `--export <file>` - Save to file

## Examples
```bash
# View backend services
homelab traefik services

# Export to CSV
homelab traefik services --output csv --export services.csv

# View middlewares (short alias)
homelab traefik mw

# Export to JSON file
homelab traefik middlewares --output json --export middlewares.json

# YAML to stdout
homelab traefik services --output yaml
```

## What's Shown

### Services Command
- Service name
- Type (loadbalancer, etc.)
- Backend server pool
- Load balancing strategy (round-robin, weighted)
- Health status with color coding

### Middlewares Command
- Middleware name
- Type (basicAuth, compress, headers, redirectScheme)
- Status (enabled/disabled)
- Configuration key-value pairs

## Implementation Details
- Follows existing export pattern from VPN/DNS/Monitor commands
- Uses `IOutputFormatter` for consistent formatting
- Uses `OutputHelper.TryExportAsync` helper method
- Color-coded status indicators (🟢 green = healthy/enabled)
- Beautiful Spectre.Console tables with proper formatting

## Test Results ✅
- [x] `homelab traefik services` displays table
- [x] `homelab traefik middlewares` displays table
- [x] JSON export works (`--output json`)
- [x] CSV export to file works (`--output csv --export file.csv`)
- [x] YAML export works (`--output yaml`)
- [x] Alias `mw` works for middlewares
- [x] Build succeeds without errors

## CSV Export Example
```csv
Name,Type,Status,LoadBalancer
adguard-service,loadbalancer,healthy,round-robin
grafana-service,loadbalancer,healthy,weighted
prometheus-service,loadbalancer,healthy,round-robin
```

## Complete Traefik Command Suite
Now complete with 4 commands:
1. ✅ `homelab traefik status` - Overview dashboard
2. ✅ `homelab traefik routes` - HTTP routers
3. ✅ `homelab traefik services` - Backend services (NEW)
4. ✅ `homelab traefik middlewares` - Middlewares (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)