### PR TITLE
feat: Phase 1 - Network Scanning with nmap

### DIFF
--- a/src/HomeLab.Cli/Commands/CompletionCommand.cs
+++ b/src/HomeLab.Cli/Commands/CompletionCommand.cs
@@ -50,7 +50,7 @@ _homelab_completions()
     _init_completion || return
 
     # Top-level commands
-    local commands=""status st service svc config logs image-update cleanup version self-update tui ui dashboard vpn dns monitor remote uptime speedtest ha traefik quick-restart qr quick-update qu quick-backup qb quick-fix qf completion""
+    local commands=""status st service svc config logs image-update cleanup version self-update tui ui dashboard vpn dns monitor remote uptime speedtest ha traefik network quick-restart qr quick-update qu quick-backup qb quick-fix qf completion""
 
     # VPN subcommands
     local vpn_commands=""status ls list add-peer add remove-peer rm remove""
@@ -75,6 +75,9 @@ _homelab_completions()
 
     # Traefik subcommands
     local traefik_commands=""status st routes services middlewares mw""
+
+    # Network subcommands
+    local network_commands=""scan ports""
 
     # Common flags
     local output_flags=""--output --export""
@@ -109,6 +112,9 @@ _homelab_completions()
                 ;;
             traefik)
                 COMPREPLY=( $(compgen -W ""$traefik_commands"" -- ""$cur"") )
+                ;;
+            network)
+                COMPREPLY=( $(compgen -W ""$network_commands"" -- ""$cur"") )
                 ;;
             completion)
                 COMPREPLY=( $(compgen -W ""bash zsh"" -- ""$cur"") )
@@ -166,6 +172,7 @@ _homelab() {
                 ""speedtest[Monitor internet connection speed]"" \
                 ""ha[Control Home Assistant smart home devices]"" \
                 ""traefik[Manage Traefik reverse proxy]"" \
+                ""network[Network scanning and monitoring]"" \
                 ""quick-restart[Quick restart a service]"" \
                 ""qr[Alias for quick-restart]"" \
                 ""quick-update[Quick update service]"" \
@@ -248,6 +255,11 @@ _homelab() {
                         ""services[List all backend services]"" \
                         ""middlewares[List all middlewares]"" \
                         ""mw[Alias for middlewares]""
+                    ;;
+                network)
+                    _values ""network commands"" \
+                        ""scan[Discover devices on network]"" \
+                        ""ports[Scan ports on devices]""
                     ;;
                 completion)
                     _values ""shell types"" \

--- a/src/HomeLab.Cli/Commands/Network/NetworkPortsCommand.cs
+++ b/src/HomeLab.Cli/Commands/Network/NetworkPortsCommand.cs
@@ -1,0 +1,127 @@
+using System.ComponentModel;
+using HomeLab.Cli.Services.Network;
+using HomeLab.Cli.Services.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Network;
+
+/// <summary>
+/// Scans ports on a specific device.
+/// </summary>
+public class NetworkPortsCommand : AsyncCommand<NetworkPortsCommand.Settings>
+{
+    private readonly INmapService _nmapService;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--device <IP>")]
+        [Description("IP address of device to scan")]
+        public string? Device { get; set; }
+
+        [CommandOption("--common")]
+        [Description("Scan only common ports (faster)")]
+        public bool CommonOnly { get; set; } = true;
+
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public NetworkPortsCommand(INmapService nmapService, IOutputFormatter formatter)
+    {
+        _nmapService = nmapService;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Port Scan")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        // Check if nmap is available
+        if (!_nmapService.IsNmapAvailable())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] nmap is not installed");
+            AnsiConsole.MarkupLine("[yellow]Install it with:[/] [cyan]brew install nmap[/]");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(settings.Device))
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Please specify a device IP address with --device");
+            AnsiConsole.MarkupLine("[yellow]Example:[/] [cyan]homelab network ports --device 192.168.1.10[/]");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] nmap is available\n");
+
+        // Scan ports
+        List<HomeLab.Cli.Models.PortScanResult>? results = null;
+
+        var scanType = settings.CommonOnly ? "common ports" : "ports 1-1000";
+        await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .StartAsync($"Scanning {scanType} on {settings.Device}...", async ctx =>
+            {
+                results = await _nmapService.ScanPortsAsync(settings.Device, settings.CommonOnly);
+            });
+
+        if (results == null || results.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No open ports found[/]");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[green]Found {results.Count} open port(s)[/]\n");
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, results))
+        {
+            return 0;
+        }
+
+        // Create table
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[cyan]Port[/]");
+        table.AddColumn("[cyan]Protocol[/]");
+        table.AddColumn("[cyan]State[/]");
+        table.AddColumn("[cyan]Service[/]");
+        table.AddColumn("[cyan]Version[/]");
+
+        foreach (var result in results.OrderBy(r => r.Port))
+        {
+            var stateColor = result.State == "open" ? "green" : "yellow";
+            var version = result.Version ?? "-";
+            if (!string.IsNullOrEmpty(result.ExtraInfo))
+            {
+                version += $" ({result.ExtraInfo})";
+            }
+
+            table.AddRow(
+                result.Port.ToString(),
+                result.Protocol,
+                $"[{stateColor}]{result.State}[/]",
+                result.Service,
+                version
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[dim]Scan completed at {DateTime.Now:yyyy-MM-dd HH:mm:ss}[/]");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Commands/Network/NetworkScanCommand.cs
+++ b/src/HomeLab.Cli/Commands/Network/NetworkScanCommand.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel;
+using HomeLab.Cli.Services.Network;
+using HomeLab.Cli.Services.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Network;
+
+/// <summary>
+/// Scans the network for active devices.
+/// </summary>
+public class NetworkScanCommand : AsyncCommand<NetworkScanCommand.Settings>
+{
+    private readonly INmapService _nmapService;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--range <CIDR>")]
+        [Description("Network range to scan (e.g., 192.168.1.0/24)")]
+        public string? Range { get; set; }
+
+        [CommandOption("--quick")]
+        [Description("Quick scan (no port detection, faster)")]
+        public bool Quick { get; set; }
+
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public NetworkScanCommand(INmapService nmapService, IOutputFormatter formatter)
+    {
+        _nmapService = nmapService;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Network Scan")
+                .Centered()
+                .Color(Color.Green));
+
+        AnsiConsole.WriteLine();
+
+        // Check if nmap is available
+        if (!_nmapService.IsNmapAvailable())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] nmap is not installed");
+            AnsiConsole.MarkupLine("[yellow]Install it with:[/] [cyan]brew install nmap[/]");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] nmap is available\n");
+
+        // Default network range
+        var networkRange = settings.Range ?? "192.168.1.0/24";
+
+        // Scan network
+        List<HomeLab.Cli.Models.NetworkDevice>? devices = null;
+
+        await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .StartAsync($"Scanning network {networkRange}...", async ctx =>
+            {
+                devices = await _nmapService.ScanNetworkAsync(networkRange, settings.Quick);
+            });
+
+        if (devices == null || devices.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No devices found[/]");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[green]Found {devices.Count} device(s)[/]\n");
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, devices))
+        {
+            return 0;
+        }
+
+        // Create table
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[cyan]IP Address[/]");
+        table.AddColumn("[cyan]MAC Address[/]");
+        table.AddColumn("[cyan]Hostname[/]");
+        table.AddColumn("[cyan]Vendor[/]");
+        table.AddColumn("[cyan]Open Ports[/]");
+        table.AddColumn("[cyan]OS Guess[/]");
+
+        foreach (var device in devices.OrderBy(d => d.IpAddress))
+        {
+            var ports = device.OpenPorts.Count > 0
+                ? string.Join(", ", device.OpenPorts.Take(10))  // Show first 10 ports
+                : "-";
+
+            if (device.OpenPorts.Count > 10)
+            {
+                ports += $" (+{device.OpenPorts.Count - 10} more)";
+            }
+
+            table.AddRow(
+                device.IpAddress,
+                device.MacAddress ?? "-",
+                device.Hostname ?? "-",
+                device.Vendor ?? "-",
+                ports,
+                device.OsGuess ?? "-"
+            );
+        }
+
+        AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[dim]Scan completed at {DateTime.Now:yyyy-MM-dd HH:mm:ss}[/]");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Models/NetworkDevice.cs
+++ b/src/HomeLab.Cli/Models/NetworkDevice.cs
@@ -1,0 +1,47 @@
+namespace HomeLab.Cli.Models;
+
+/// <summary>
+/// Represents a network device discovered during scanning.
+/// </summary>
+public class NetworkDevice
+{
+    /// <summary>
+    /// IP address of the device.
+    /// </summary>
+    public string IpAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// MAC address of the device (if available).
+    /// </summary>
+    public string? MacAddress { get; set; }
+
+    /// <summary>
+    /// Hostname of the device (if available).
+    /// </summary>
+    public string? Hostname { get; set; }
+
+    /// <summary>
+    /// Vendor name based on MAC address lookup (if available).
+    /// </summary>
+    public string? Vendor { get; set; }
+
+    /// <summary>
+    /// List of open ports detected on the device.
+    /// </summary>
+    public List<int> OpenPorts { get; set; } = new();
+
+    /// <summary>
+    /// Operating system detection result (if available).
+    /// </summary>
+    public string? OsGuess { get; set; }
+
+    /// <summary>
+    /// Device status (up, down).
+    /// </summary>
+    public string Status { get; set; } = "up";
+
+    /// <summary>
+    /// Timestamp when the device was scanned.
+    /// </summary>
+    public DateTime ScannedAt { get; set; } = DateTime.Now;
+}

--- a/src/HomeLab.Cli/Models/PortScanResult.cs
+++ b/src/HomeLab.Cli/Models/PortScanResult.cs
@@ -1,0 +1,42 @@
+namespace HomeLab.Cli.Models;
+
+/// <summary>
+/// Represents a port scan result for a specific device.
+/// </summary>
+public class PortScanResult
+{
+    /// <summary>
+    /// IP address of the scanned device.
+    /// </summary>
+    public string IpAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Port number.
+    /// </summary>
+    public int Port { get; set; }
+
+    /// <summary>
+    /// Protocol (tcp, udp).
+    /// </summary>
+    public string Protocol { get; set; } = "tcp";
+
+    /// <summary>
+    /// Service name running on the port (if detected).
+    /// </summary>
+    public string Service { get; set; } = "unknown";
+
+    /// <summary>
+    /// Port state (open, closed, filtered).
+    /// </summary>
+    public string State { get; set; } = "unknown";
+
+    /// <summary>
+    /// Service version (if detected).
+    /// </summary>
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Additional information about the service.
+    /// </summary>
+    public string? ExtraInfo { get; set; }
+}

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -2,6 +2,7 @@ using HomeLab.Cli.Commands;
 using HomeLab.Cli.Commands.Dns;
 using HomeLab.Cli.Commands.HomeAssistant;
 using HomeLab.Cli.Commands.Monitor;
+using HomeLab.Cli.Commands.Network;
 using HomeLab.Cli.Commands.Quick;
 using HomeLab.Cli.Commands.Remote;
 using HomeLab.Cli.Commands.Speedtest;
@@ -12,6 +13,7 @@ using HomeLab.Cli.Services.Abstractions;
 using HomeLab.Cli.Services.Configuration;
 using HomeLab.Cli.Services.Docker;
 using HomeLab.Cli.Services.Health;
+using HomeLab.Cli.Services.Network;
 using HomeLab.Cli.Services.Output;
 using HomeLab.Cli.Services.ServiceDiscovery;
 using HomeLab.Cli.Services.Update;
@@ -50,6 +52,9 @@ public static class Program
 
         // Phase 10: Self-update service
         services.AddSingleton<IGitHubReleaseService, GitHubReleaseService>();
+
+        // Network monitoring services
+        services.AddSingleton<INmapService, NmapService>();
 
         // Create registrar to connect Spectre with DI
         var registrar = new TypeRegistrar(services);
@@ -214,6 +219,16 @@ public static class Program
                 traefik.AddCommand<TraefikMiddlewaresCommand>("middlewares")
                     .WithAlias("mw")
                     .WithDescription("List all middlewares");
+            });
+
+            // Network Monitoring - Phase 1: Scanning
+            config.AddBranch("network", network =>
+            {
+                network.SetDescription("Network scanning and monitoring");
+                network.AddCommand<NetworkScanCommand>("scan")
+                    .WithDescription("Discover devices on network");
+                network.AddCommand<NetworkPortsCommand>("ports")
+                    .WithDescription("Scan ports on devices");
             });
 
             // Phase 7: Quick Actions - Fast operations for daily use

--- a/src/HomeLab.Cli/Services/Mocks/MockNmapService.cs
+++ b/src/HomeLab.Cli/Services/Mocks/MockNmapService.cs
@@ -1,0 +1,164 @@
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Network;
+
+namespace HomeLab.Cli.Services.Mocks;
+
+/// <summary>
+/// Mock implementation of nmap service for testing without actual nmap installation.
+/// </summary>
+public class MockNmapService : INmapService
+{
+    public bool IsNmapAvailable()
+    {
+        return true;  // Always return true in mock mode
+    }
+
+    public Task<List<NetworkDevice>> ScanNetworkAsync(string networkRange, bool quickScan = false)
+    {
+        // Return mock network devices
+        var devices = new List<NetworkDevice>
+        {
+            new()
+            {
+                IpAddress = "192.168.1.1",
+                MacAddress = "00:11:22:33:44:55",
+                Hostname = "gateway.local",
+                Vendor = "Ubiquiti Networks",
+                OpenPorts = new List<int> { 80, 443, 22 },
+                OsGuess = "Linux 5.x",
+                Status = "up",
+                ScannedAt = DateTime.Now
+            },
+            new()
+            {
+                IpAddress = "192.168.1.10",
+                MacAddress = "AA:BB:CC:DD:EE:FF",
+                Hostname = "mac-mini.local",
+                Vendor = "Apple, Inc.",
+                OpenPorts = new List<int> { 22, 80, 443, 3000, 3001, 9090 },
+                OsGuess = "macOS 14.x",
+                Status = "up",
+                ScannedAt = DateTime.Now
+            },
+            new()
+            {
+                IpAddress = "192.168.1.20",
+                MacAddress = "11:22:33:44:55:66",
+                Hostname = "iphone.local",
+                Vendor = "Apple, Inc.",
+                OpenPorts = new List<int>(),
+                OsGuess = "iOS 17.x",
+                Status = "up",
+                ScannedAt = DateTime.Now
+            },
+            new()
+            {
+                IpAddress = "192.168.1.30",
+                MacAddress = "AA:BB:CC:DD:EE:11",
+                Hostname = "raspberry-pi.local",
+                Vendor = "Raspberry Pi Foundation",
+                OpenPorts = new List<int> { 22, 80 },
+                OsGuess = "Linux 6.x",
+                Status = "up",
+                ScannedAt = DateTime.Now
+            },
+            new()
+            {
+                IpAddress = "192.168.1.50",
+                MacAddress = "FF:EE:DD:CC:BB:AA",
+                Hostname = "smart-tv.local",
+                Vendor = "Samsung Electronics",
+                OpenPorts = new List<int> { 8080 },
+                OsGuess = "Linux (embedded)",
+                Status = "up",
+                ScannedAt = DateTime.Now
+            }
+        };
+
+        return Task.FromResult(devices);
+    }
+
+    public Task<List<PortScanResult>> ScanPortsAsync(string ipAddress, bool commonPortsOnly = true)
+    {
+        // Return mock port scan results
+        var results = new List<PortScanResult>
+        {
+            new()
+            {
+                IpAddress = ipAddress,
+                Port = 22,
+                Protocol = "tcp",
+                Service = "ssh",
+                State = "open",
+                Version = "OpenSSH 9.0",
+                ExtraInfo = "protocol 2.0"
+            },
+            new()
+            {
+                IpAddress = ipAddress,
+                Port = 80,
+                Protocol = "tcp",
+                Service = "http",
+                State = "open",
+                Version = "nginx 1.24.0",
+                ExtraInfo = null
+            },
+            new()
+            {
+                IpAddress = ipAddress,
+                Port = 443,
+                Protocol = "tcp",
+                Service = "https",
+                State = "open",
+                Version = "nginx 1.24.0",
+                ExtraInfo = null
+            },
+            new()
+            {
+                IpAddress = ipAddress,
+                Port = 3000,
+                Protocol = "tcp",
+                Service = "http",
+                State = "open",
+                Version = "AdGuard Home",
+                ExtraInfo = null
+            },
+            new()
+            {
+                IpAddress = ipAddress,
+                Port = 9090,
+                Protocol = "tcp",
+                Service = "http",
+                State = "open",
+                Version = "Prometheus",
+                ExtraInfo = null
+            }
+        };
+
+        if (!commonPortsOnly)
+        {
+            // Add more ports for full scan
+            results.AddRange(new[]
+            {
+                new PortScanResult
+                {
+                    IpAddress = ipAddress,
+                    Port = 8080,
+                    Protocol = "tcp",
+                    Service = "http-proxy",
+                    State = "open"
+                },
+                new PortScanResult
+                {
+                    IpAddress = ipAddress,
+                    Port = 5432,
+                    Protocol = "tcp",
+                    Service = "postgresql",
+                    State = "open"
+                }
+            });
+        }
+
+        return Task.FromResult(results);
+    }
+}

--- a/src/HomeLab.Cli/Services/Network/INmapService.cs
+++ b/src/HomeLab.Cli/Services/Network/INmapService.cs
@@ -1,0 +1,31 @@
+using HomeLab.Cli.Models;
+
+namespace HomeLab.Cli.Services.Network;
+
+/// <summary>
+/// Service interface for network scanning using nmap.
+/// </summary>
+public interface INmapService
+{
+    /// <summary>
+    /// Scans a network range for active devices.
+    /// </summary>
+    /// <param name="networkRange">CIDR network range (e.g., "192.168.1.0/24")</param>
+    /// <param name="quickScan">If true, performs quick scan without port detection</param>
+    /// <returns>List of discovered network devices</returns>
+    Task<List<NetworkDevice>> ScanNetworkAsync(string networkRange, bool quickScan = false);
+
+    /// <summary>
+    /// Scans ports on a specific device.
+    /// </summary>
+    /// <param name="ipAddress">IP address of the device to scan</param>
+    /// <param name="commonPortsOnly">If true, scans only common ports (faster)</param>
+    /// <returns>List of port scan results</returns>
+    Task<List<PortScanResult>> ScanPortsAsync(string ipAddress, bool commonPortsOnly = true);
+
+    /// <summary>
+    /// Checks if nmap is installed and available.
+    /// </summary>
+    /// <returns>True if nmap is available, false otherwise</returns>
+    bool IsNmapAvailable();
+}

--- a/src/HomeLab.Cli/Services/Network/NmapService.cs
+++ b/src/HomeLab.Cli/Services/Network/NmapService.cs
@@ -1,0 +1,239 @@
+using System.Diagnostics;
+using System.Xml.Linq;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Configuration;
+
+namespace HomeLab.Cli.Services.Network;
+
+/// <summary>
+/// Real implementation of nmap network scanning service.
+/// Executes nmap CLI commands and parses XML output.
+/// </summary>
+public class NmapService : INmapService
+{
+    private readonly IHomelabConfigService _configService;
+    private const string NmapCommand = "nmap";
+
+    public NmapService(IHomelabConfigService configService)
+    {
+        _configService = configService;
+    }
+
+    public bool IsNmapAvailable()
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = NmapCommand,
+                    Arguments = "--version",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<List<NetworkDevice>> ScanNetworkAsync(string networkRange, bool quickScan = false)
+    {
+        if (!IsNmapAvailable())
+        {
+            throw new InvalidOperationException(
+                "nmap is not installed. Install it with: brew install nmap");
+        }
+
+        // Build nmap arguments
+        // -sn: Ping scan (no port scan) for quick discovery
+        // -sT: TCP connect scan (no sudo required)
+        // -oX -: Output XML to stdout
+        var args = quickScan
+            ? $"-sn -oX - {networkRange}"
+            : $"-sT -T4 -F -oX - {networkRange}";  // -T4: faster, -F: fast (100 common ports)
+
+        var xmlOutput = await ExecuteNmapAsync(args);
+        return ParseNetworkScanXml(xmlOutput);
+    }
+
+    public async Task<List<PortScanResult>> ScanPortsAsync(string ipAddress, bool commonPortsOnly = true)
+    {
+        if (!IsNmapAvailable())
+        {
+            throw new InvalidOperationException(
+                "nmap is not installed. Install it with: brew install nmap");
+        }
+
+        // Build nmap arguments
+        // -sT: TCP connect scan (no sudo required)
+        // -p-: All ports OR -F: Fast (100 common ports)
+        // -sV: Version detection
+        var portRange = commonPortsOnly ? "-F" : "-p 1-1000";  // Limit to 1-1000 for reasonable time
+        var args = $"-sT {portRange} -sV -oX - {ipAddress}";
+
+        var xmlOutput = await ExecuteNmapAsync(args);
+        return ParsePortScanXml(xmlOutput, ipAddress);
+    }
+
+    private async Task<string> ExecuteNmapAsync(string arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = NmapCommand,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"nmap failed with exit code {process.ExitCode}: {error}");
+        }
+
+        return output;
+    }
+
+    private List<NetworkDevice> ParseNetworkScanXml(string xmlOutput)
+    {
+        var devices = new List<NetworkDevice>();
+
+        try
+        {
+            var doc = XDocument.Parse(xmlOutput);
+            var hosts = doc.Descendants("host");
+
+            foreach (var host in hosts)
+            {
+                var status = host.Element("status")?.Attribute("state")?.Value;
+                if (status != "up")
+                {
+                    continue;
+                }
+
+                var device = new NetworkDevice
+                {
+                    Status = status ?? "up",
+                    ScannedAt = DateTime.Now
+                };
+
+                // Get IP address
+                var address = host.Element("address");
+                if (address?.Attribute("addrtype")?.Value == "ipv4")
+                {
+                    device.IpAddress = address.Attribute("addr")?.Value ?? "";
+                }
+
+                // Get MAC address and vendor
+                var macAddress = host.Elements("address")
+                    .FirstOrDefault(a => a.Attribute("addrtype")?.Value == "mac");
+                if (macAddress != null)
+                {
+                    device.MacAddress = macAddress.Attribute("addr")?.Value;
+                    device.Vendor = macAddress.Attribute("vendor")?.Value;
+                }
+
+                // Get hostname
+                var hostname = host.Element("hostnames")?.Element("hostname")?.Attribute("name")?.Value;
+                device.Hostname = hostname;
+
+                // Get open ports
+                var ports = host.Element("ports")?.Elements("port")
+                    .Where(p => p.Element("state")?.Attribute("state")?.Value == "open")
+                    .Select(p => int.TryParse(p.Attribute("portid")?.Value, out var port) ? port : 0)
+                    .Where(p => p > 0)
+                    .ToList();
+
+                device.OpenPorts = ports ?? new List<int>();
+
+                // Get OS guess (if available)
+                var osMatch = host.Element("os")?.Element("osmatch")?.Attribute("name")?.Value;
+                device.OsGuess = osMatch;
+
+                devices.Add(device);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to parse nmap XML output: {ex.Message}", ex);
+        }
+
+        return devices;
+    }
+
+    private List<PortScanResult> ParsePortScanXml(string xmlOutput, string ipAddress)
+    {
+        var results = new List<PortScanResult>();
+
+        try
+        {
+            var doc = XDocument.Parse(xmlOutput);
+            var host = doc.Descendants("host").FirstOrDefault();
+
+            if (host == null)
+            {
+                return results;
+            }
+
+            var ports = host.Element("ports")?.Elements("port");
+            if (ports == null)
+            {
+                return results;
+            }
+
+            foreach (var port in ports)
+            {
+                var state = port.Element("state")?.Attribute("state")?.Value;
+                if (state == "closed" || state == "filtered")
+                {
+                    continue;  // Only show open ports
+                }
+
+                var portId = port.Attribute("portid")?.Value;
+                var protocol = port.Attribute("protocol")?.Value ?? "tcp";
+                var service = port.Element("service");
+
+                var result = new PortScanResult
+                {
+                    IpAddress = ipAddress,
+                    Port = int.TryParse(portId, out var p) ? p : 0,
+                    Protocol = protocol,
+                    State = state ?? "unknown",
+                    Service = service?.Attribute("name")?.Value ?? "unknown",
+                    Version = service?.Attribute("version")?.Value,
+                    ExtraInfo = service?.Attribute("extrainfo")?.Value
+                };
+
+                results.Add(result);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to parse nmap port scan XML output: {ex.Message}", ex);
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
Implements Issue #34 - Network device discovery and port scanning.

## Summary

Adds network scanning capabilities using nmap for device discovery and port scanning. This is Phase 1 of the Network Monitoring feature.

## Features

### Commands
- `homelab network scan` - Discover all devices on network
  - `--range CIDR` - Custom network range (default: 192.168.1.0/24)
  - `--quick` - Quick scan without port detection
  - `--output json|csv|yaml|table` - Output format
  - `--export FILE` - Export to file

- `homelab network ports` - Scan ports on a specific device
  - `--device IP` - IP address to scan
  - `--common` - Scan only common ports (default, faster)
  - `--output` and `--export` support

### Services
- `INmapService` - Interface for network scanning
- `NmapService` - Real implementation (executes nmap CLI)
- `MockNmapService` - Mock for testing without nmap

### Models
- `NetworkDevice` - Represents discovered network device
- `PortScanResult` - Represents port scan result

## Technical Implementation

- **Nmap execution**: Uses `Process.Start()` with `-sT` scan (no sudo required)
- **XML parsing**: Uses `System.Xml.Linq.XDocument` to parse nmap XML output
- **Error handling**: Checks if nmap is installed, provides helpful error message
- **Shell completion**: Added to both bash and zsh completion scripts
- **DI registration**: Registered `INmapService` in Program.cs
- **Pattern compliance**: Follows existing command and service patterns

## Testing

- ✅ Build succeeds (no warnings)
- ✅ All existing tests pass (12/12)
- ✅ Code formatted with `dotnet format`
- ✅ Mock service works without nmap installed
- ✅ Real service works with nmap installed

## Prerequisites

For real scanning (not mocked):
```bash
brew install nmap
```

## Examples

```bash
# Scan local network
homelab network scan

# Scan custom range
homelab network scan --range 10.0.0.0/24

# Quick scan (no port detection)
homelab network scan --quick

# Scan ports on a device
homelab network ports --device 192.168.1.100

# Export to JSON
homelab network scan --output json --export devices.json
```

## Next Steps

After merge:
- Phase 2: Traffic monitoring with ntopng (#35)
- Phase 3: Intrusion detection with Suricata (#36)
- Phase 4: Testing and documentation (#37)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)