### PR TITLE
fix: enable dynamic versioning from git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ jobs:
           --self-contained \
           -p:PublishSingleFile=true \
           -p:PublishTrimmed=false \
-          -p:Version=${{ steps.version.outputs.version }}
+          -p:Version=${{ steps.version.outputs.version }} \
+          -p:AssemblyVersion=${{ steps.version.outputs.version }} \
+          -p:FileVersion=${{ steps.version.outputs.version }} \
+          -p:InformationalVersion=${{ steps.version.outputs.version }}
 
     - name: Prepare binary for upload
       run: |

--- a/src/HomeLab.Cli/HomeLab.Cli.csproj
+++ b/src/HomeLab.Cli/HomeLab.Cli.csproj
@@ -7,10 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- Version Information -->
-    <Version>1.8.0</Version>
-    <AssemblyVersion>1.8.0.0</AssemblyVersion>
-    <FileVersion>1.8.0.0</FileVersion>
-    <InformationalVersion>1.8.0</InformationalVersion>
+    <!-- Version is set dynamically during build via -p:Version parameter -->
     <Product>HomeLab CLI</Product>
     <Authors>HomeLab Team</Authors>
     <Description>Command-line tool for managing Mac Mini M4 homelab services</Description>


### PR DESCRIPTION
## Problem

Self-update command always fails with version comparison because all releases report version 1.8.0 regardless of git tag.

**Root Cause**: The `.csproj` file has hardcoded version properties that override the build-time `-p:Version` parameter.

**Evidence**:
```bash
# v1.9.1 release shows version 1.8.0
$ homelab version
Version: 1.8.0+8d44d25b059725e3eccb998b0df8f9e81632f6ed
```

## Solution

1. **Remove hardcoded version from .csproj**: Let build process set version dynamically
2. **Update release workflow**: Explicitly set all version properties (Version, AssemblyVersion, FileVersion, InformationalVersion)

## Changes

### `src/HomeLab.Cli/HomeLab.Cli.csproj`
- Removed hardcoded `<Version>1.8.0</Version>`
- Removed hardcoded `<AssemblyVersion>1.8.0.0</AssemblyVersion>`
- Removed hardcoded `<FileVersion>1.8.0.0</FileVersion>`
- Removed hardcoded `<InformationalVersion>1.8.0</InformationalVersion>`
- Added comment explaining version is set during build

### `.github/workflows/release.yml`
- Added explicit `-p:AssemblyVersion=$VERSION`
- Added explicit `-p:FileVersion=$VERSION`
- Added explicit `-p:InformationalVersion=$VERSION`

## Testing

Built locally with version parameters:
```bash
dotnet publish -p:Version=1.9.2 -p:AssemblyVersion=1.9.2 \
  -p:FileVersion=1.9.2 -p:InformationalVersion=1.9.2

$ ./bin/.../HomeLab.Cli version
Version: 1.9.2+8d44d25b059725e3eccb998b0df8f9e81632f6ed
```

## Impact

After this fix and releasing v1.9.2:
- ✅ `homelab version` will show correct version
- ✅ `homelab self-update` version comparison will work
- ✅ Users can update from 1.8.0 → 1.9.2

## Related

Part of fixing self-update functionality after #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)