### PR TITLE
feat: enhance TV control with apps, remote keys, and smart wake

### DIFF
--- a/docs/TV_CONTROL.md
+++ b/docs/TV_CONTROL.md
@@ -1,0 +1,252 @@
+# TV Control - LG WebOS Smart TV
+
+Control your LG WebOS TV from the command line. Wake it up, launch apps, send remote keys, and more.
+
+---
+
+## Quick Start
+
+```bash
+# First time setup - pair with your TV
+homelab tv setup
+
+# Turn TV on
+homelab tv on
+
+# Turn TV on and launch an app
+homelab tv on --app netflix
+
+# Turn TV on, launch app, and start playing
+homelab tv on --app default --key enter
+
+# Turn TV off
+homelab tv off
+```
+
+---
+
+## Setup
+
+### 1. Find Your TV's IP and MAC Address
+
+- **IP Address**: Check your router's connected devices, or go to TV Settings > Network
+- **MAC Address**: TV Settings > Network > Wi-Fi/Wired Connection > Advanced Settings
+
+### 2. Run Setup Wizard
+
+```bash
+homelab tv setup --ip 192.168.1.102 --mac AA:BB:CC:DD:EE:FF --name "Living Room TV"
+```
+
+Or run interactively:
+```bash
+homelab tv setup
+```
+
+### 3. Accept Pairing on TV
+
+When prompted, a pairing dialog will appear on your TV screen. Use your remote to accept it.
+
+### 4. Set Default App (Optional)
+
+Edit `~/.homelab/tv.json` and add your preferred app:
+```json
+{
+  "DefaultApp": "netflix"
+}
+```
+
+Use `homelab tv apps` to see available app IDs.
+
+---
+
+## Commands
+
+### `tv status`
+Check if TV is online and paired.
+
+```bash
+homelab tv status
+```
+
+### `tv on`
+Turn TV on using Wake-on-LAN.
+
+```bash
+# Just turn on
+homelab tv on
+
+# Turn on and launch app
+homelab tv on --app netflix
+homelab tv on --app default    # uses DefaultApp from config
+
+# Turn on, launch app, and send keys
+homelab tv on --app default --key enter
+homelab tv on --app youtube -k enter -k enter  # multiple keys
+```
+
+**Options:**
+- `-a, --app <APP>` - Launch app after wake (use app ID, name, or "default")
+- `-k, --key <KEY>` - Send remote key after app loads (can be used multiple times)
+- `--delay <MS>` - Delay between key presses (default: 500ms)
+
+### `tv off`
+Turn TV off via WebOS API.
+
+```bash
+homelab tv off
+```
+
+### `tv apps`
+List all installed apps on your TV.
+
+```bash
+homelab tv apps
+```
+
+Shows app names and IDs. Use the ID with `tv launch` or `tv on --app`.
+
+### `tv launch <app>`
+Launch an app on the TV.
+
+```bash
+homelab tv launch netflix
+homelab tv launch youtube
+homelab tv launch com.disney.disneyplus-prod
+```
+
+Supports partial name matching - `netflix` will find the Netflix app.
+
+### `tv key <key>`
+Send a remote control key to the TV.
+
+```bash
+homelab tv key enter    # Press OK/Enter
+homelab tv key back     # Go back
+homelab tv key play     # Play media
+homelab tv key pause    # Pause media
+```
+
+**Available Keys:**
+| Key | Description |
+|-----|-------------|
+| `ENTER` / `OK` | Select/Confirm |
+| `BACK` | Go back |
+| `HOME` | Home screen |
+| `UP`, `DOWN`, `LEFT`, `RIGHT` | Navigation |
+| `PLAY`, `PAUSE`, `STOP` | Media controls |
+| `VOLUMEUP`, `VOLUMEDOWN`, `MUTE` | Volume |
+| `CHANNELUP`, `CHANNELDOWN` | Channels |
+| `0`-`9` | Number keys |
+| `RED`, `GREEN`, `YELLOW`, `BLUE` | Color buttons |
+
+### `tv debug`
+Debug TV connection and app detection.
+
+```bash
+homelab tv debug
+```
+
+Shows current foreground app and connection status.
+
+---
+
+## Use Cases
+
+### Leave TV on for Pets
+
+Turn on TV, launch your IPTV app, and start playing:
+
+```bash
+homelab tv on --app default --key enter
+```
+
+Set your IPTV app as default in `~/.homelab/tv.json`:
+```json
+{
+  "DefaultApp": "cz.sledovanitv.rikplus"
+}
+```
+
+### Quick Netflix
+
+```bash
+homelab tv on --app netflix
+```
+
+### Remote Control from Terminal
+
+```bash
+# Navigate menu
+homelab tv key up
+homelab tv key down
+homelab tv key enter
+
+# Control playback
+homelab tv key play
+homelab tv key pause
+
+# Adjust volume
+homelab tv key volumeup
+homelab tv key mute
+```
+
+---
+
+## Troubleshooting
+
+### "TV not configured"
+Run `homelab tv setup` first.
+
+### "TV not paired"
+Run `homelab tv setup` and accept the pairing prompt on your TV.
+
+### Pairing prompt doesn't appear
+1. Make sure TV is ON (not in standby)
+2. Enable "LG Connect Apps" in TV settings
+3. Try with `--verbose` flag: `homelab tv setup --verbose`
+
+### Keys not working
+1. Check app is fully loaded (try longer delay)
+2. Use `--verbose` to debug: `homelab tv key enter --verbose`
+3. Try `ENTER` vs `OK` - some apps respond to one or the other
+
+### Connection timeout
+1. Check TV is on the same network
+2. Verify IP address: `ping <tv-ip>`
+3. Check WebSocket ports: `nc -zv <tv-ip> 3000`
+
+---
+
+## Configuration
+
+Config file: `~/.homelab/tv.json`
+
+```json
+{
+  "Name": "Living Room TV",
+  "IpAddress": "192.168.1.102",
+  "MacAddress": "AA:BB:CC:DD:EE:FF",
+  "ClientKey": "auto-generated-after-pairing",
+  "Type": 0,
+  "DefaultApp": "netflix"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `Name` | Friendly name for display |
+| `IpAddress` | TV's IP address |
+| `MacAddress` | TV's MAC address (for Wake-on-LAN) |
+| `ClientKey` | Auto-generated pairing key |
+| `Type` | TV type (0 = LG WebOS) |
+| `DefaultApp` | App to launch with `--app default` |
+
+---
+
+## Requirements
+
+- LG WebOS Smart TV (2016 or newer)
+- TV connected to same network (or accessible via VPN)
+- Wake-on-LAN enabled on TV (for `tv on`)
+- "LG Connect Apps" enabled (for pairing)

--- a/src/HomeLab.Cli/Commands/Tv/TvAppsCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tv/TvAppsCommand.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.LgTv;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tv;
+
+public class TvAppsCommand : AsyncCommand<TvAppsCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [System.ComponentModel.Description("Show detailed debug output")]
+        [CommandOption("-v|--verbose")]
+        public bool Verbose { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var config = await LoadTvConfigAsync();
+        if (config == null)
+        {
+            AnsiConsole.MarkupLine("[red]TV not configured. Run 'homelab tv setup' first.[/]");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(config.ClientKey))
+        {
+            AnsiConsole.MarkupLine("[red]TV not paired. Run 'homelab tv setup' to pair.[/]");
+            return 1;
+        }
+
+        var client = new LgTvClient();
+        if (settings.Verbose)
+        {
+            client.SetVerboseLogging(msg => AnsiConsole.MarkupLine($"[dim]{msg.EscapeMarkup()}[/]"));
+        }
+
+        try
+        {
+            List<TvApp> apps = new();
+            if (settings.Verbose)
+            {
+                await client.ConnectAsync(config.IpAddress, config.ClientKey);
+                apps = await client.GetAppsAsync();
+            }
+            else
+            {
+                await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync($"Connecting to {config.Name}...", async _ =>
+                {
+                    await client.ConnectAsync(config.IpAddress, config.ClientKey);
+                    apps = await client.GetAppsAsync();
+                });
+            }
+
+            if (apps.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]No apps found.[/]");
+                return 0;
+            }
+
+            var table = new Table()
+                .Border(TableBorder.Rounded)
+                .AddColumn("App Name")
+                .AddColumn("App ID (use with 'tv launch')");
+
+            foreach (var app in apps.OrderBy(a => a.Name))
+            {
+                table.AddRow(app.Name, $"[dim]{app.Id}[/]");
+            }
+
+            AnsiConsole.Write(new Rule($"[blue]Installed Apps on {config.Name}[/]").RuleStyle("grey"));
+            AnsiConsole.Write(table);
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[dim]Launch an app:[/] [cyan]homelab tv launch <app-id>[/]");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed: {ex.Message}[/]");
+            return 1;
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static async Task<TvConfig?> LoadTvConfigAsync()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".homelab", "tv.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TvConfig>(await File.ReadAllTextAsync(path));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tv/TvDebugCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tv/TvDebugCommand.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.LgTv;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tv;
+
+public class TvDebugCommand : AsyncCommand<TvDebugCommand.Settings>
+{
+    public class Settings : CommandSettings { }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var config = await LoadTvConfigAsync();
+        if (config == null)
+        {
+            AnsiConsole.MarkupLine("[red]TV not configured.[/]");
+            return 1;
+        }
+
+        var client = new LgTvClient();
+        client.SetVerboseLogging(msg => AnsiConsole.MarkupLine($"[dim]{msg.EscapeMarkup()}[/]"));
+
+        try
+        {
+            await client.ConnectAsync(config.IpAddress, config.ClientKey);
+            var foregroundApp = await client.GetForegroundAppAsync();
+            AnsiConsole.MarkupLine($"[green]Foreground app:[/] {foregroundApp ?? "(none)"}");
+            AnsiConsole.MarkupLine($"[dim]Expected app:[/] {config.DefaultApp ?? "(not set)"}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed: {ex.Message}[/]");
+            return 1;
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static async Task<TvConfig?> LoadTvConfigAsync()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".homelab", "tv.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TvConfig>(await File.ReadAllTextAsync(path));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tv/TvKeyCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tv/TvKeyCommand.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel;
+using System.Text.Json;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.LgTv;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tv;
+
+public class TvKeyCommand : AsyncCommand<TvKeyCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        [Description("Remote key to send (ENTER, OK, UP, DOWN, LEFT, RIGHT, BACK, PLAY, PAUSE, etc.)")]
+        public string Key { get; set; } = string.Empty;
+
+        [CommandOption("-v|--verbose")]
+        [Description("Show detailed debug output")]
+        public bool Verbose { get; set; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var config = await LoadTvConfigAsync();
+        if (config == null)
+        {
+            AnsiConsole.MarkupLine("[red]TV not configured. Run 'homelab tv setup' first.[/]");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(config.ClientKey))
+        {
+            AnsiConsole.MarkupLine("[red]TV not paired. Run 'homelab tv setup' to pair.[/]");
+            return 1;
+        }
+
+        var client = new LgTvClient();
+        if (settings.Verbose)
+        {
+            client.SetVerboseLogging(msg => AnsiConsole.MarkupLine($"[dim]{msg.EscapeMarkup()}[/]"));
+        }
+
+        try
+        {
+            if (settings.Verbose)
+            {
+                await client.ConnectAsync(config.IpAddress, config.ClientKey);
+                await client.SendKeyAsync(settings.Key);
+            }
+            else
+            {
+                await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync($"Sending {settings.Key.ToUpper()}...", async _ =>
+                {
+                    await client.ConnectAsync(config.IpAddress, config.ClientKey);
+                    await client.SendKeyAsync(settings.Key);
+                });
+            }
+
+            AnsiConsole.MarkupLine($"[green]Sent key: {settings.Key.ToUpper()}[/]");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed: {ex.Message}[/]");
+            return 1;
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static async Task<TvConfig?> LoadTvConfigAsync()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".homelab", "tv.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TvConfig>(await File.ReadAllTextAsync(path));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tv/TvLaunchCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tv/TvLaunchCommand.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel;
+using System.Text.Json;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.LgTv;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tv;
+
+public class TvLaunchCommand : AsyncCommand<TvLaunchCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<APP>")]
+        [Description("App ID or partial name to launch (use 'tv apps' to see available apps)")]
+        public string App { get; set; } = string.Empty;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var config = await LoadTvConfigAsync();
+        if (config == null)
+        {
+            AnsiConsole.MarkupLine("[red]TV not configured. Run 'homelab tv setup' first.[/]");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(config.ClientKey))
+        {
+            AnsiConsole.MarkupLine("[red]TV not paired. Run 'homelab tv setup' to pair.[/]");
+            return 1;
+        }
+
+        var client = new LgTvClient();
+        try
+        {
+            string? appIdToLaunch = null;
+            string? appName = null;
+
+            await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync($"Connecting to {config.Name}...", async _ =>
+            {
+                await client.ConnectAsync(config.IpAddress, config.ClientKey);
+
+                // Get list of apps to find the right one
+                var apps = await client.GetAppsAsync();
+
+                // Try exact ID match first
+                var exactMatch = apps.FirstOrDefault(a =>
+                    a.Id.Equals(settings.App, StringComparison.OrdinalIgnoreCase));
+
+                if (exactMatch != null)
+                {
+                    appIdToLaunch = exactMatch.Id;
+                    appName = exactMatch.Name;
+                }
+                else
+                {
+                    // Try partial name match
+                    var partialMatch = apps.FirstOrDefault(a =>
+                        a.Name.Contains(settings.App, StringComparison.OrdinalIgnoreCase) ||
+                        a.Id.Contains(settings.App, StringComparison.OrdinalIgnoreCase));
+
+                    if (partialMatch != null)
+                    {
+                        appIdToLaunch = partialMatch.Id;
+                        appName = partialMatch.Name;
+                    }
+                }
+            });
+
+            if (appIdToLaunch == null)
+            {
+                AnsiConsole.MarkupLine($"[red]App '{settings.App}' not found.[/]");
+                AnsiConsole.MarkupLine("[dim]Use[/] [cyan]homelab tv apps[/] [dim]to see available apps.[/]");
+                return 1;
+            }
+
+            await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync($"Launching {appName}...", async _ =>
+            {
+                await client.LaunchAppAsync(appIdToLaunch);
+            });
+
+            AnsiConsole.MarkupLine($"[green]Launched {appName}![/]");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed: {ex.Message}[/]");
+            return 1;
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static async Task<TvConfig?> LoadTvConfigAsync()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".homelab", "tv.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TvConfig>(await File.ReadAllTextAsync(path));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tv/TvOnCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tv/TvOnCommand.cs
@@ -1,6 +1,8 @@
+using System.ComponentModel;
 using System.Text.Json;
 using HomeLab.Cli.Models;
 using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.LgTv;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -9,7 +11,21 @@ namespace HomeLab.Cli.Commands.Tv;
 public class TvOnCommand : AsyncCommand<TvOnCommand.Settings>
 {
     private readonly IWakeOnLanService _wolService;
-    public class Settings : CommandSettings { }
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("-a|--app <APP>")]
+        [Description("Launch app after TV wakes up (use app ID or name, or 'default' for saved default)")]
+        public string? App { get; set; }
+
+        [CommandOption("-k|--key <KEY>")]
+        [Description("Send remote key after app launches (e.g., ENTER, OK, PLAY). Can be used multiple times.")]
+        public string[]? Keys { get; set; }
+
+        [CommandOption("--delay <MS>")]
+        [Description("Delay in ms between key presses (default: 500)")]
+        public int KeyDelay { get; set; } = 500;
+    }
 
     public TvOnCommand(IWakeOnLanService wolService) => _wolService = wolService;
 
@@ -18,25 +34,161 @@ public class TvOnCommand : AsyncCommand<TvOnCommand.Settings>
         var config = await LoadTvConfigAsync();
         if (config == null) { AnsiConsole.MarkupLine("[red]TV not configured. Run 'homelab tv setup' first.[/]"); return 1; }
 
+        // Determine which app to launch
+        string? appToLaunch = null;
+        if (!string.IsNullOrEmpty(settings.App))
+        {
+            appToLaunch = settings.App.Equals("default", StringComparison.OrdinalIgnoreCase)
+                ? config.DefaultApp
+                : settings.App;
+        }
+
         AnsiConsole.MarkupLine($"[dim]Sending Wake-on-LAN to {config.Name}...[/]");
         var success = await _wolService.WakeAsync(config.MacAddress);
-        if (success)
+        if (!success)
         {
-            AnsiConsole.MarkupLine($"[green]Magic packet sent to {config.Name}![/]");
-            await Task.Delay(5000);
+            AnsiConsole.MarkupLine("[red]Failed to send Wake-on-LAN packet.[/]");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine($"[green]Magic packet sent to {config.Name}![/]");
+
+        // Wait for TV to boot
+        AnsiConsole.MarkupLine("[dim]Waiting for TV to boot...[/]");
+        var bootTimeout = DateTime.Now.AddSeconds(15);
+        var isOnline = false;
+
+        while (DateTime.Now < bootTimeout)
+        {
+            await Task.Delay(2000);
             if (await _wolService.IsReachableAsync(config.IpAddress))
             {
-                AnsiConsole.MarkupLine($"[green]{config.Name} is now online![/]");
+                isOnline = true;
+                break;
             }
-            else
-            {
-                AnsiConsole.MarkupLine("[yellow]TV may take a moment to boot.[/]");
-            }
-
-            return 0;
         }
-        AnsiConsole.MarkupLine("[red]Failed to send Wake-on-LAN packet.[/]");
-        return 1;
+
+        if (isOnline)
+        {
+            AnsiConsole.MarkupLine($"[green]{config.Name} is now online![/]");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[yellow]TV may still be booting...[/]");
+        }
+
+        // Launch app if requested
+        if (!string.IsNullOrEmpty(appToLaunch) && !string.IsNullOrEmpty(config.ClientKey))
+        {
+            // Give TV a moment to fully initialize WebOS
+            await Task.Delay(3000);
+
+            var client = new LgTvClient();
+            try
+            {
+                string? appName = null;
+                string? launchedAppId = null;
+                await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync($"Launching {appToLaunch}...", async _ =>
+                {
+                    await client.ConnectAsync(config.IpAddress, config.ClientKey);
+
+                    // Find the app
+                    var apps = await client.GetAppsAsync();
+                    var match = apps.FirstOrDefault(a =>
+                        a.Id.Equals(appToLaunch, StringComparison.OrdinalIgnoreCase) ||
+                        a.Name.Contains(appToLaunch, StringComparison.OrdinalIgnoreCase));
+
+                    if (match != null)
+                    {
+                        await client.LaunchAppAsync(match.Id);
+                        appName = match.Name;
+                        launchedAppId = match.Id;
+                    }
+                });
+
+                if (appName != null)
+                {
+                    AnsiConsole.MarkupLine($"[green]Launched {appName}![/]");
+
+                    // Send keys if requested
+                    if (settings.Keys != null && settings.Keys.Length > 0 && launchedAppId != null)
+                    {
+                        // Wait for app to be in foreground
+                        AnsiConsole.MarkupLine("[dim]Waiting for app to be ready...[/]");
+                        var appReady = await client.WaitForAppAsync(launchedAppId, 30);
+
+                        if (appReady)
+                        {
+                            // Extra delay for UI to fully render
+                            await Task.Delay(3000);
+
+                            foreach (var key in settings.Keys)
+                            {
+                                try
+                                {
+                                    await client.SendKeyAsync(key);
+                                    AnsiConsole.MarkupLine($"[dim]Sent key: {key.ToUpper()}[/]");
+                                    await Task.Delay(settings.KeyDelay);
+                                }
+                                catch (Exception ex)
+                                {
+                                    AnsiConsole.MarkupLine($"[yellow]Could not send key '{key}': {ex.Message}[/]");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            AnsiConsole.MarkupLine("[yellow]App didn't start in time, skipping keys.[/]");
+                        }
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[yellow]App '{appToLaunch}' not found.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[yellow]Could not launch app: {ex.Message}[/]");
+            }
+            finally
+            {
+                await client.DisconnectAsync();
+            }
+        }
+        else if (!string.IsNullOrEmpty(appToLaunch) && string.IsNullOrEmpty(config.ClientKey))
+        {
+            AnsiConsole.MarkupLine("[yellow]TV not paired - cannot launch app. Run 'homelab tv setup' to pair.[/]");
+        }
+
+        // Send keys even without app launch (if TV is already on)
+        if (settings.Keys != null && settings.Keys.Length > 0 && string.IsNullOrEmpty(appToLaunch) && !string.IsNullOrEmpty(config.ClientKey))
+        {
+            var client = new LgTvClient();
+            try
+            {
+                await client.ConnectAsync(config.IpAddress, config.ClientKey);
+                foreach (var key in settings.Keys)
+                {
+                    try
+                    {
+                        await client.SendKeyAsync(key);
+                        AnsiConsole.MarkupLine($"[dim]Sent key: {key.ToUpper()}[/]");
+                        await Task.Delay(settings.KeyDelay);
+                    }
+                    catch (Exception ex)
+                    {
+                        AnsiConsole.MarkupLine($"[yellow]Could not send key '{key}': {ex.Message}[/]");
+                    }
+                }
+            }
+            finally
+            {
+                await client.DisconnectAsync();
+            }
+        }
+
+        return 0;
     }
 
     private static async Task<TvConfig?> LoadTvConfigAsync()

--- a/src/HomeLab.Cli/Models/TvConfig.cs
+++ b/src/HomeLab.Cli/Models/TvConfig.cs
@@ -10,6 +10,7 @@ public class TvConfig
     public string MacAddress { get; set; } = "";
     public string? ClientKey { get; set; }
     public TvType Type { get; set; } = TvType.LgWebOs;
+    public string? DefaultApp { get; set; }
 }
 
 /// <summary>

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -261,6 +261,14 @@ public static class Program
                     .WithDescription("Turn TV off via WebOS API");
                 tv.AddCommand<TvSetupCommand>("setup")
                     .WithDescription("Configure and pair with TV");
+                tv.AddCommand<TvAppsCommand>("apps")
+                    .WithDescription("List installed apps on TV");
+                tv.AddCommand<TvLaunchCommand>("launch")
+                    .WithDescription("Launch an app on TV");
+                tv.AddCommand<TvKeyCommand>("key")
+                    .WithDescription("Send remote control key to TV");
+                tv.AddCommand<TvDebugCommand>("debug")
+                    .WithDescription("Debug TV connection and app detection");
             });
 
             // Phase 7: Quick Actions - Fast operations for daily use

--- a/src/HomeLab.Cli/Services/LgTv/LgTvClient.cs
+++ b/src/HomeLab.Cli/Services/LgTv/LgTvClient.cs
@@ -16,6 +16,7 @@ public class LgTvClient : ILgTvClient
     private int _messageId = 1;
     private readonly Dictionary<string, TaskCompletionSource<JsonElement>> _pendingRequests = new();
     private static readonly int[] WebSocketPorts = { 3000, 3001 }; // 3000=ws, 3001=wss
+    private Action<string>? _logAction;
 
     private const string RegisterPayload = @"{
         ""forcePairing"": false,
@@ -23,18 +24,49 @@ public class LgTvClient : ILgTvClient
         ""manifest"": {
             ""manifestVersion"": 1,
             ""appVersion"": ""1.1"",
-            ""permissions"": [""CONTROL_POWER"", ""CONTROL_AUDIO"", ""LAUNCH"", ""READ_INSTALLED_APPS""]
+            ""permissions"": [
+                ""CONTROL_POWER"",
+                ""CONTROL_AUDIO"",
+                ""CONTROL_INPUT_TV"",
+                ""CONTROL_INPUT_MEDIA_PLAYBACK"",
+                ""CONTROL_MOUSE_AND_KEYBOARD"",
+                ""CONTROL_CHANNEL_UP_DOWN"",
+                ""LAUNCH"",
+                ""READ_INSTALLED_APPS"",
+                ""READ_TV_CHANNEL_LIST"",
+                ""READ_CURRENT_CHANNEL"",
+                ""READ_INPUT_DEVICE_LIST"",
+                ""READ_RUNNING_APPS"",
+                ""WRITE_NOTIFICATION_TOAST""
+            ]
         }
     }";
+
+    /// <summary>
+    /// Sets the logging action for verbose output.
+    /// </summary>
+    public void SetVerboseLogging(Action<string> logAction) => _logAction = logAction;
+
+    private void Log(string message)
+    {
+        _logAction?.Invoke(message);
+    }
 
     public async Task<string?> ConnectAsync(string ipAddress, string? clientKey = null)
     {
         _clientKey = clientKey;
         Exception? lastException = null;
 
+        Log($"Starting connection to {ipAddress}");
+        Log($"Existing client key: {(string.IsNullOrEmpty(clientKey) ? "(none - will need pairing)" : "(provided)")}");
+
         // Try both ports (3000 for older TVs, 3001 for newer TVs with SSL)
         foreach (var port in WebSocketPorts)
         {
+            var scheme = port == 3001 ? "wss" : "ws";
+            var uri = new Uri($"{scheme}://{ipAddress}:{port}");
+            Log($"Trying {uri}...");
+
             try
             {
                 _webSocket = new ClientWebSocket();
@@ -42,13 +74,13 @@ public class LgTvClient : ILgTvClient
                 if (port == 3001)
                 {
                     _webSocket.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+                    Log("  SSL certificate validation disabled for self-signed cert");
                 }
 
-                var scheme = port == 3001 ? "wss" : "ws";
-                var uri = new Uri($"{scheme}://{ipAddress}:{port}");
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
                 await _webSocket.ConnectAsync(uri, cts.Token);
+                Log($"  WebSocket connected successfully");
 
                 _ = ReceiveMessagesAsync();
 
@@ -56,36 +88,84 @@ public class LgTvClient : ILgTvClient
                 if (!string.IsNullOrEmpty(_clientKey))
                 {
                     payload["client-key"] = _clientKey;
+                    Log("  Including existing client key in registration");
                 }
 
                 var registerMessage = new { type = "register", id = "register_0", payload };
+                var jsonToSend = JsonSerializer.Serialize(registerMessage, new JsonSerializerOptions { WriteIndented = true });
+                Log($"  Sending registration message:\n{jsonToSend}");
                 await SendMessageAsync(registerMessage);
 
                 var tcs = new TaskCompletionSource<JsonElement>();
                 _pendingRequests["register_0"] = tcs;
 
+                Log("  Waiting for TV response (30s timeout)...");
+                Log("  >>> Check your TV screen for pairing prompt! <<<");
+
                 var response = await Task.WhenAny(tcs.Task, Task.Delay(30000));
                 if (response != tcs.Task)
                 {
+                    Log("  TIMEOUT - No response from TV");
                     throw new TimeoutException("Registration timed out. Did you accept the prompt on the TV?");
                 }
 
                 var result = await tcs.Task;
+                var resultJson = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+                Log($"  Received response:\n{resultJson}");
+
+                // Check for client key in first response
                 if (result.TryGetProperty("client-key", out var keyElement))
                 {
                     _clientKey = keyElement.GetString();
+                    Log($"  Got client key: {_clientKey?[..Math.Min(8, _clientKey?.Length ?? 0)]}...");
                 }
 
-                // If we got here but no client key, pairing wasn't accepted
+                // If no client key yet, TV is showing prompt - wait for second response after user accepts
                 if (string.IsNullOrEmpty(_clientKey))
                 {
+                    // Check if TV acknowledged the prompt request
+                    if (result.TryGetProperty("pairingType", out var pairingType) &&
+                        pairingType.GetString() == "PROMPT")
+                    {
+                        Log("  TV acknowledged prompt request, waiting for user to accept on TV...");
+                        Log("  >>> LOOK AT YOUR TV SCREEN AND ACCEPT THE PAIRING PROMPT! <<<");
+
+                        // Wait for the second response with the client key
+                        var tcs2 = new TaskCompletionSource<JsonElement>();
+                        _pendingRequests["register_0"] = tcs2;
+
+                        var response2 = await Task.WhenAny(tcs2.Task, Task.Delay(30000));
+                        if (response2 != tcs2.Task)
+                        {
+                            Log("  TIMEOUT waiting for pairing acceptance");
+                            throw new TimeoutException("Pairing timed out. Did you accept the prompt on the TV?");
+                        }
+
+                        var result2 = await tcs2.Task;
+                        var result2Json = JsonSerializer.Serialize(result2, new JsonSerializerOptions { WriteIndented = true });
+                        Log($"  Received second response:\n{result2Json}");
+
+                        if (result2.TryGetProperty("client-key", out var keyElement2))
+                        {
+                            _clientKey = keyElement2.GetString();
+                            Log($"  Got client key: {_clientKey?[..Math.Min(8, _clientKey?.Length ?? 0)]}...");
+                        }
+                    }
+                }
+
+                // Final check for client key
+                if (string.IsNullOrEmpty(_clientKey))
+                {
+                    Log("  ERROR: No client key in response");
                     throw new InvalidOperationException("TV responded but no client key received. Did you accept the pairing prompt on TV?");
                 }
 
+                Log("  SUCCESS - Pairing complete!");
                 return _clientKey;
             }
             catch (Exception ex)
             {
+                Log($"  FAILED: {ex.GetType().Name}: {ex.Message}");
                 lastException = ex;
                 await DisconnectAsync();
                 // Try next port
@@ -147,6 +227,120 @@ public class LgTvClient : ILgTvClient
     public async Task SetMuteAsync(bool mute) => await SendRequestAsync("ssap://audio/setMute", new { mute });
     public async Task LaunchAppAsync(string appId) => await SendRequestAsync("ssap://system.launcher/launch", new { id = appId });
 
+    /// <summary>
+    /// Get the currently running foreground app.
+    /// </summary>
+    public async Task<string?> GetForegroundAppAsync()
+    {
+        var response = await SendRequestAsync("ssap://com.webos.applicationManager/getForegroundAppInfo", null);
+        if (response.TryGetProperty("appId", out var appIdElement))
+        {
+            return appIdElement.GetString();
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Wait for a specific app to be in the foreground.
+    /// </summary>
+    public async Task<bool> WaitForAppAsync(string appId, int timeoutSeconds = 30)
+    {
+        var deadline = DateTime.Now.AddSeconds(timeoutSeconds);
+        while (DateTime.Now < deadline)
+        {
+            try
+            {
+                var currentApp = await GetForegroundAppAsync();
+                Log($"  Current foreground app: {currentApp}");
+                if (currentApp != null && currentApp.Equals(appId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore errors during polling
+            }
+            await Task.Delay(1000);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Send a remote control key press to the TV.
+    /// </summary>
+    public async Task SendKeyAsync(string key)
+    {
+        // Get the pointer input socket
+        var response = await SendRequestAsync("ssap://com.webos.service.networkinput/getPointerInputSocket", null);
+        if (!response.TryGetProperty("socketPath", out var socketPathElement))
+        {
+            throw new InvalidOperationException("Could not get input socket path");
+        }
+
+        var socketPath = socketPathElement.GetString();
+        if (string.IsNullOrEmpty(socketPath))
+        {
+            throw new InvalidOperationException("Empty input socket path");
+        }
+
+        Log($"  Got input socket: {socketPath}");
+
+        // Connect to the input socket
+        using var inputSocket = new ClientWebSocket();
+        inputSocket.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+
+        await inputSocket.ConnectAsync(new Uri(socketPath), CancellationToken.None);
+        Log($"  Connected to input socket");
+
+        // Send the key press (format: type:button\nname:KEY\n\n)
+        var keyCommand = $"type:button\nname:{key.ToUpper()}\n\n";
+        var keyBytes = Encoding.UTF8.GetBytes(keyCommand);
+        await inputSocket.SendAsync(keyBytes, WebSocketMessageType.Text, true, CancellationToken.None);
+        Log($"  Sent key: {key.ToUpper()}");
+
+        // Small delay to let the TV process the key
+        await Task.Delay(100);
+
+        await inputSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Done", CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Common remote control keys.
+    /// </summary>
+    public static class Keys
+    {
+        public const string Enter = "ENTER";
+        public const string Back = "BACK";
+        public const string Home = "HOME";
+        public const string Up = "UP";
+        public const string Down = "DOWN";
+        public const string Left = "LEFT";
+        public const string Right = "RIGHT";
+        public const string Play = "PLAY";
+        public const string Pause = "PAUSE";
+        public const string Stop = "STOP";
+        public const string VolumeUp = "VOLUMEUP";
+        public const string VolumeDown = "VOLUMEDOWN";
+        public const string Mute = "MUTE";
+        public const string ChannelUp = "CHANNELUP";
+        public const string ChannelDown = "CHANNELDOWN";
+        public const string Red = "RED";
+        public const string Green = "GREEN";
+        public const string Yellow = "YELLOW";
+        public const string Blue = "BLUE";
+        public const string Num0 = "0";
+        public const string Num1 = "1";
+        public const string Num2 = "2";
+        public const string Num3 = "3";
+        public const string Num4 = "4";
+        public const string Num5 = "5";
+        public const string Num6 = "6";
+        public const string Num7 = "7";
+        public const string Num8 = "8";
+        public const string Num9 = "9";
+    }
+
     public async Task<int> GetVolumeAsync()
     {
         var response = await SendRequestAsync("ssap://audio/getVolume", null);
@@ -200,6 +394,8 @@ public class LgTvClient : ILgTvClient
     private async Task ReceiveMessagesAsync()
     {
         var buffer = new byte[4096];
+        var messageBuffer = new List<byte>();
+
         try
         {
             while (_webSocket != null && _webSocket.State == WebSocketState.Open)
@@ -210,7 +406,16 @@ public class LgTvClient : ILgTvClient
                     break;
                 }
 
-                ProcessMessage(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                // Append chunk to message buffer
+                messageBuffer.AddRange(buffer.Take(result.Count));
+
+                // Only process when we have the complete message
+                if (result.EndOfMessage)
+                {
+                    var fullMessage = Encoding.UTF8.GetString(messageBuffer.ToArray());
+                    messageBuffer.Clear();
+                    ProcessMessage(fullMessage);
+                }
             }
         }
         catch { }
@@ -220,10 +425,19 @@ public class LgTvClient : ILgTvClient
     {
         try
         {
+            Log($"  [RECV] {json}");
             var root = JsonDocument.Parse(json).RootElement;
+
+            // Log message type if present
+            if (root.TryGetProperty("type", out var typeElement))
+            {
+                Log($"  Message type: {typeElement.GetString()}");
+            }
+
             if (root.TryGetProperty("id", out var idElement))
             {
                 var id = idElement.GetString();
+                Log($"  Message ID: {id}");
                 if (id != null && _pendingRequests.TryGetValue(id, out var tcs))
                 {
                     _pendingRequests.Remove(id);
@@ -231,6 +445,9 @@ public class LgTvClient : ILgTvClient
                 }
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Log($"  [ERROR] Failed to process message: {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `tv apps` command to list installed apps on TV
- Add `tv launch` command to launch apps by ID or name
- Add `tv key` command to send remote control keys (ENTER, BACK, PLAY, etc.)
- Add `--app` flag to `tv on` for launching app after wake
- Add `--key` flag to `tv on` for sending keys after app loads
- Add smart app detection - waits for app to be in foreground before sending keys
- Add `--verbose` flag to `tv setup` for debugging pairing issues
- Add `tv debug` command for troubleshooting
- Fix WebSocket message buffering for large responses (apps list was getting truncated)
- Fix two-phase pairing flow (TV sends acknowledgment then client key)
- Add all WebOS permissions for full TV control
- Add `DefaultApp` config option for quick wake+launch
- Add comprehensive `docs/TV_CONTROL.md` documentation

## Use Case
Wake TV, launch IPTV app, and start playing a channel - all in one command:
```bash
homelab tv on --app default --key enter
```

Perfect for leaving TV on for pets while at work!

## New Commands
| Command | Description |
|---------|-------------|
| `tv apps` | List installed apps |
| `tv launch <app>` | Launch an app |
| `tv key <key>` | Send remote key |
| `tv debug` | Debug connection |

## Test plan
- [x] `tv setup --verbose` shows detailed pairing flow
- [x] `tv apps` lists all installed apps
- [x] `tv launch netflix` launches Netflix
- [x] `tv key enter` sends ENTER key
- [x] `tv on --app default --key enter` does full wake+app+play flow
- [x] Documentation added

🤖 Generated with [Claude Code](https://claude.com/claude-code)