### PR TITLE
feat: add Tailscale VPN integration

### DIFF
--- a/config/homelab-cli.yaml.example
+++ b/config/homelab-cli.yaml.example
@@ -24,6 +24,9 @@ services:
     password: "admin"
     enabled: true
 
+  tailscale:
+    enabled: true
+
 remote:
   mac_mini:
     host: "192.168.1.100"  # Update with your Mac Mini IP

--- a/src/HomeLab.Cli/Commands/Tailscale/TailscaleDevicesCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tailscale/TailscaleDevicesCommand.cs
@@ -1,0 +1,145 @@
+using System.ComponentModel;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tailscale;
+
+public class TailscaleDevicesCommand : AsyncCommand<TailscaleDevicesCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--online")]
+        [Description("Show only online devices")]
+        public bool OnlineOnly { get; set; }
+
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public TailscaleDevicesCommand(IServiceClientFactory clientFactory, IOutputFormatter formatter)
+    {
+        _clientFactory = clientFactory;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Tailscale Devices")
+                .Centered()
+                .Color(Color.Cyan));
+
+        AnsiConsole.WriteLine();
+
+        var client = _clientFactory.CreateTailscaleClient();
+
+        if (!await client.IsTailscaleInstalledAsync())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Tailscale CLI is not installed");
+            return 1;
+        }
+
+        await AnsiConsole.Status()
+            .StartAsync("Fetching devices...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                await Task.Delay(300);
+            });
+
+        var status = await client.GetStatusAsync();
+
+        if (!status.IsConnected)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Not connected to Tailscale");
+            AnsiConsole.MarkupLine("Use [cyan]homelab tailscale up[/] to connect.");
+            return 1;
+        }
+
+        // Build device list (self + peers)
+        var allDevices = new List<TailscaleDevice>();
+        if (status.Self != null)
+        {
+            allDevices.Add(status.Self);
+        }
+
+        allDevices.AddRange(status.Peers);
+
+        var devices = settings.OnlineOnly
+            ? allDevices.Where(d => d.Online).ToList()
+            : allDevices;
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, devices))
+        {
+            return 0;
+        }
+
+        if (devices.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No devices found.[/]");
+            return 0;
+        }
+
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]Hostname[/]");
+        table.AddColumn("[yellow]Status[/]");
+        table.AddColumn("[yellow]Tailscale IP[/]");
+        table.AddColumn("[yellow]DNS Name[/]");
+        table.AddColumn("[yellow]OS[/]");
+        table.AddColumn("[yellow]Last Seen[/]");
+
+        foreach (var device in devices.OrderByDescending(d => d.Online).ThenBy(d => d.HostName))
+        {
+            var isSelf = status.Self != null && device.Id == status.Self.Id;
+            var hostNameDisplay = isSelf ? $"{device.HostName} [dim](self)[/]" : device.HostName;
+
+            var statusColor = device.Online ? "green" : "red";
+            var statusText = device.Online ? "Online" : "Offline";
+
+            var lastSeen = device.LastSeen.HasValue
+                ? FormatTimeAgo(device.LastSeen.Value)
+                : (device.Online ? "Now" : "Never");
+
+            table.AddRow(
+                hostNameDisplay,
+                $"[{statusColor}]{statusText}[/]",
+                device.PrimaryIP ?? "N/A",
+                $"[dim]{device.DNSName}[/]",
+                device.OS,
+                $"[dim]{lastSeen}[/]");
+        }
+
+        AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        var onlineCount = devices.Count(d => d.Online);
+        AnsiConsole.Write(
+            new Panel($"[green]Online:[/] {onlineCount}  [yellow]Total:[/] {devices.Count}")
+                .Header("[yellow]Summary[/]")
+                .BorderColor(Color.Grey)
+                .RoundedBorder());
+
+        return 0;
+    }
+
+    private static string FormatTimeAgo(DateTime dateTime)
+    {
+        var timeAgo = DateTime.UtcNow - dateTime;
+        if (timeAgo.TotalMinutes < 1) return "Just now";
+        if (timeAgo.TotalMinutes < 60) return $"{(int)timeAgo.TotalMinutes}m ago";
+        if (timeAgo.TotalHours < 24) return $"{(int)timeAgo.TotalHours}h ago";
+        return $"{(int)timeAgo.TotalDays}d ago";
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tailscale/TailscaleDownCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tailscale/TailscaleDownCommand.cs
@@ -1,0 +1,46 @@
+using HomeLab.Cli.Services.Abstractions;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tailscale;
+
+public class TailscaleDownCommand : AsyncCommand<TailscaleDownCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+
+    public class Settings : CommandSettings { }
+
+    public TailscaleDownCommand(IServiceClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var client = _clientFactory.CreateTailscaleClient();
+
+        if (!await client.IsTailscaleInstalledAsync())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Tailscale CLI is not installed");
+            return 1;
+        }
+
+        var currentStatus = await client.GetStatusAsync();
+        if (!currentStatus.IsConnected)
+        {
+            AnsiConsole.MarkupLine("[yellow]![/] Tailscale is already disconnected");
+            return 0;
+        }
+
+        await AnsiConsole.Status()
+            .StartAsync("Disconnecting from Tailscale...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                await client.DisconnectAsync();
+            });
+
+        AnsiConsole.MarkupLine("[green]✓[/] Disconnected from Tailscale");
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tailscale/TailscaleStatusCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tailscale/TailscaleStatusCommand.cs
@@ -1,0 +1,161 @@
+using System.ComponentModel;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.Output;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tailscale;
+
+public class TailscaleStatusCommand : AsyncCommand<TailscaleStatusCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+    private readonly IOutputFormatter _formatter;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--output <FORMAT>")]
+        [Description("Output format: table, json, csv, yaml")]
+        public string? OutputFormat { get; set; }
+
+        [CommandOption("--export <FILE>")]
+        [Description("Export to file")]
+        public string? ExportFile { get; set; }
+    }
+
+    public TailscaleStatusCommand(IServiceClientFactory clientFactory, IOutputFormatter formatter)
+    {
+        _clientFactory = clientFactory;
+        _formatter = formatter;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        AnsiConsole.Write(
+            new FigletText("Tailscale Status")
+                .Centered()
+                .Color(Color.Blue));
+
+        AnsiConsole.WriteLine();
+
+        var client = _clientFactory.CreateTailscaleClient();
+
+        if (!await client.IsTailscaleInstalledAsync())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Tailscale CLI is not installed");
+            AnsiConsole.MarkupLine("\nInstall with: [cyan]brew install tailscale[/]");
+            return 1;
+        }
+
+        await AnsiConsole.Status()
+            .StartAsync("Checking Tailscale status...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                await Task.Delay(300);
+            });
+
+        var status = await client.GetStatusAsync();
+
+        var statusColor = status.IsConnected ? "green" : "red";
+        var statusIcon = status.IsConnected ? "✓" : "✗";
+        AnsiConsole.MarkupLine($"[{statusColor}]{statusIcon}[/] Tailscale is [bold]{status.BackendState}[/]\n");
+
+        // Try export if requested
+        if (await OutputHelper.TryExportAsync(_formatter, settings.OutputFormat, settings.ExportFile, status))
+        {
+            return 0;
+        }
+
+        // Connection info panel
+        var connectionGrid = new Grid();
+        connectionGrid.AddColumn();
+        connectionGrid.AddColumn();
+
+        connectionGrid.AddRow(
+            new Markup("[yellow]Tailnet:[/]"),
+            new Markup($"[cyan]{status.TailnetName ?? "N/A"}[/]"));
+        connectionGrid.AddRow(
+            new Markup("[yellow]Backend State:[/]"),
+            new Markup($"[cyan]{status.BackendState}[/]"));
+
+        if (status.Self != null)
+        {
+            connectionGrid.AddRow(
+                new Markup("[yellow]Hostname:[/]"),
+                new Markup($"[cyan]{status.Self.HostName}[/]"));
+            connectionGrid.AddRow(
+                new Markup("[yellow]Tailscale IP:[/]"),
+                new Markup($"[cyan]{status.Self.PrimaryIP ?? "N/A"}[/]"));
+            connectionGrid.AddRow(
+                new Markup("[yellow]DNS Name:[/]"),
+                new Markup($"[dim]{status.Self.DNSName}[/]"));
+        }
+
+        var version = await client.GetVersionAsync();
+        connectionGrid.AddRow(
+            new Markup("[yellow]Version:[/]"),
+            new Markup($"[dim]{version ?? "Unknown"}[/]"));
+
+        AnsiConsole.Write(
+            new Panel(connectionGrid)
+                .Header("[yellow]Connection Info[/]")
+                .BorderColor(Color.Green)
+                .RoundedBorder());
+
+        // Peers table
+        if (status.IsConnected && status.Peers.Count > 0)
+        {
+            AnsiConsole.WriteLine();
+
+            var table = new Table();
+            table.Border(TableBorder.Rounded);
+            table.AddColumn("[yellow]Hostname[/]");
+            table.AddColumn("[yellow]Status[/]");
+            table.AddColumn("[yellow]Tailscale IP[/]");
+            table.AddColumn("[yellow]OS[/]");
+            table.AddColumn("[yellow]Last Seen[/]");
+
+            foreach (var peer in status.Peers.OrderBy(p => p.HostName))
+            {
+                var onlineColor = peer.Online ? "green" : "red";
+                var onlineText = peer.Online ? "Online" : "Offline";
+                var lastSeen = peer.LastSeen.HasValue
+                    ? FormatTimeAgo(peer.LastSeen.Value)
+                    : "Never";
+
+                table.AddRow(
+                    peer.HostName,
+                    $"[{onlineColor}]{onlineText}[/]",
+                    peer.PrimaryIP ?? "N/A",
+                    peer.OS,
+                    $"[dim]{lastSeen}[/]");
+            }
+
+            AnsiConsole.Write(table);
+
+            AnsiConsole.WriteLine();
+            var onlinePeers = status.Peers.Count(p => p.Online);
+            AnsiConsole.Write(
+                new Panel($"[green]Online:[/] {onlinePeers}  [yellow]Total:[/] {status.Peers.Count}")
+                    .Header("[yellow]Peers[/]")
+                    .BorderColor(Color.Grey)
+                    .RoundedBorder());
+        }
+        else if (!status.IsConnected)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]Tailscale is not connected.[/]");
+            AnsiConsole.MarkupLine("Use [cyan]homelab tailscale up[/] to connect.");
+        }
+
+        return 0;
+    }
+
+    private static string FormatTimeAgo(DateTime dateTime)
+    {
+        var timeAgo = DateTime.UtcNow - dateTime;
+        if (timeAgo.TotalMinutes < 1) return "Just now";
+        if (timeAgo.TotalMinutes < 60) return $"{(int)timeAgo.TotalMinutes}m ago";
+        if (timeAgo.TotalHours < 24) return $"{(int)timeAgo.TotalHours}h ago";
+        return $"{(int)timeAgo.TotalDays}d ago";
+    }
+}

--- a/src/HomeLab.Cli/Commands/Tailscale/TailscaleUpCommand.cs
+++ b/src/HomeLab.Cli/Commands/Tailscale/TailscaleUpCommand.cs
@@ -1,0 +1,61 @@
+using HomeLab.Cli.Services.Abstractions;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Tailscale;
+
+public class TailscaleUpCommand : AsyncCommand<TailscaleUpCommand.Settings>
+{
+    private readonly IServiceClientFactory _clientFactory;
+
+    public class Settings : CommandSettings { }
+
+    public TailscaleUpCommand(IServiceClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var client = _clientFactory.CreateTailscaleClient();
+
+        if (!await client.IsTailscaleInstalledAsync())
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Tailscale CLI is not installed");
+            AnsiConsole.MarkupLine("\nInstall with: [cyan]brew install tailscale[/]");
+            return 1;
+        }
+
+        var currentStatus = await client.GetStatusAsync();
+        if (currentStatus.IsConnected)
+        {
+            AnsiConsole.MarkupLine("[yellow]![/] Already connected to Tailscale");
+            AnsiConsole.MarkupLine($"  Tailnet: [cyan]{currentStatus.TailnetName}[/]");
+            if (currentStatus.Self != null)
+            {
+                AnsiConsole.MarkupLine($"  IP: [cyan]{currentStatus.Self.PrimaryIP}[/]");
+            }
+
+            return 0;
+        }
+
+        await AnsiConsole.Status()
+            .StartAsync("Connecting to Tailscale...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                await client.ConnectAsync();
+            });
+
+        AnsiConsole.MarkupLine("[green]✓[/] Connected to Tailscale");
+
+        var status = await client.GetStatusAsync();
+        if (status.Self != null)
+        {
+            AnsiConsole.MarkupLine($"  Tailnet: [cyan]{status.TailnetName}[/]");
+            AnsiConsole.MarkupLine($"  IP: [cyan]{status.Self.PrimaryIP}[/]");
+            AnsiConsole.MarkupLine($"  Hostname: [cyan]{status.Self.HostName}[/]");
+        }
+
+        return 0;
+    }
+}

--- a/src/HomeLab.Cli/Models/TailscaleStatus.cs
+++ b/src/HomeLab.Cli/Models/TailscaleStatus.cs
@@ -1,0 +1,33 @@
+namespace HomeLab.Cli.Models;
+
+/// <summary>
+/// Represents the overall Tailscale connection status.
+/// Parsed from `tailscale status --json` output.
+/// </summary>
+public class TailscaleStatus
+{
+    public string BackendState { get; set; } = "Stopped";
+    public string? TailnetName { get; set; }
+    public string? MagicDNSSuffix { get; set; }
+    public TailscaleDevice? Self { get; set; }
+    public List<TailscaleDevice> Peers { get; set; } = new();
+    public bool IsConnected => BackendState == "Running";
+}
+
+/// <summary>
+/// Represents a device on the Tailscale tailnet (self or peer).
+/// </summary>
+public class TailscaleDevice
+{
+    public string Id { get; set; } = string.Empty;
+    public string HostName { get; set; } = string.Empty;
+    public string DNSName { get; set; } = string.Empty;
+    public string OS { get; set; } = string.Empty;
+    public List<string> TailscaleIPs { get; set; } = new();
+    public bool Online { get; set; }
+    public DateTime? LastSeen { get; set; }
+    public bool ExitNode { get; set; }
+    public bool ExitNodeOption { get; set; }
+
+    public string? PrimaryIP => TailscaleIPs.FirstOrDefault();
+}

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -7,6 +7,7 @@ using HomeLab.Cli.Commands.Quick;
 using HomeLab.Cli.Commands.Remote;
 using HomeLab.Cli.Commands.Speedtest;
 using HomeLab.Cli.Commands.Traefik;
+using HomeLab.Cli.Commands.Tailscale;
 using HomeLab.Cli.Commands.Tv;
 using HomeLab.Cli.Commands.Uptime;
 using HomeLab.Cli.Commands.Vpn;
@@ -269,6 +270,22 @@ public static class Program
                     .WithDescription("Send remote control key to TV");
                 tv.AddCommand<TvDebugCommand>("debug")
                     .WithDescription("Debug TV connection and app detection");
+            });
+
+            // Tailscale VPN
+            config.AddBranch("tailscale", tailscale =>
+            {
+                tailscale.SetDescription("Manage Tailscale VPN connection");
+                tailscale.AddCommand<TailscaleStatusCommand>("status")
+                    .WithAlias("st")
+                    .WithDescription("Display Tailscale connection status");
+                tailscale.AddCommand<TailscaleUpCommand>("up")
+                    .WithDescription("Connect to Tailscale tailnet");
+                tailscale.AddCommand<TailscaleDownCommand>("down")
+                    .WithDescription("Disconnect from Tailscale tailnet");
+                tailscale.AddCommand<TailscaleDevicesCommand>("devices")
+                    .WithAlias("ls")
+                    .WithDescription("List all devices on the tailnet");
             });
 
             // Phase 7: Quick Actions - Fast operations for daily use

--- a/src/HomeLab.Cli/Services/Abstractions/IServiceClientFactory.cs
+++ b/src/HomeLab.Cli/Services/Abstractions/IServiceClientFactory.cs
@@ -54,4 +54,9 @@ public interface IServiceClientFactory
     /// Creates a Suricata client for intrusion detection.
     /// </summary>
     ISuricataClient CreateSuricataClient();
+
+    /// <summary>
+    /// Creates a Tailscale client.
+    /// </summary>
+    ITailscaleClient CreateTailscaleClient();
 }

--- a/src/HomeLab.Cli/Services/Abstractions/ITailscaleClient.cs
+++ b/src/HomeLab.Cli/Services/Abstractions/ITailscaleClient.cs
@@ -1,0 +1,17 @@
+using HomeLab.Cli.Models;
+
+namespace HomeLab.Cli.Services.Abstractions;
+
+/// <summary>
+/// Interface for Tailscale VPN operations.
+/// Wraps the tailscale CLI binary.
+/// </summary>
+public interface ITailscaleClient : IServiceClient
+{
+    Task<TailscaleStatus> GetStatusAsync();
+    Task ConnectAsync();
+    Task DisconnectAsync();
+    Task<string?> GetTailscaleIPAsync();
+    Task<bool> IsTailscaleInstalledAsync();
+    Task<string?> GetVersionAsync();
+}

--- a/src/HomeLab.Cli/Services/Abstractions/ServiceClientFactory.cs
+++ b/src/HomeLab.Cli/Services/Abstractions/ServiceClientFactory.cs
@@ -8,6 +8,7 @@ using HomeLab.Cli.Services.Ntopng;
 using HomeLab.Cli.Services.Prometheus;
 using HomeLab.Cli.Services.Speedtest;
 using HomeLab.Cli.Services.Suricata;
+using HomeLab.Cli.Services.Tailscale;
 using HomeLab.Cli.Services.Traefik;
 using HomeLab.Cli.Services.UptimeKuma;
 using HomeLab.Cli.Services.WireGuard;
@@ -121,5 +122,10 @@ public class ServiceClientFactory : IServiceClientFactory
         }
 
         return new SuricataClient(_configService);
+    }
+
+    public ITailscaleClient CreateTailscaleClient()
+    {
+        return new TailscaleClient();
     }
 }

--- a/src/HomeLab.Cli/Services/Tailscale/TailscaleClient.cs
+++ b/src/HomeLab.Cli/Services/Tailscale/TailscaleClient.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics;
+using System.Text.Json;
+using HomeLab.Cli.Models;
+using HomeLab.Cli.Services.Abstractions;
+
+namespace HomeLab.Cli.Services.Tailscale;
+
+/// <summary>
+/// Tailscale client that shells out to the tailscale CLI binary.
+/// </summary>
+public class TailscaleClient : ITailscaleClient
+{
+    private const string TailscaleCommand = "tailscale";
+
+    public string ServiceName => "Tailscale";
+
+    public async Task<bool> IsHealthyAsync()
+    {
+        try
+        {
+            var status = await GetStatusAsync();
+            return status.IsConnected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<ServiceHealthInfo> GetHealthInfoAsync()
+    {
+        var isInstalled = await IsTailscaleInstalledAsync();
+
+        if (!isInstalled)
+        {
+            return new ServiceHealthInfo
+            {
+                ServiceName = ServiceName,
+                IsHealthy = false,
+                Status = "Not Installed",
+                Message = "Tailscale CLI is not installed. Install with: brew install tailscale"
+            };
+        }
+
+        try
+        {
+            var status = await GetStatusAsync();
+            var version = await GetVersionAsync();
+            var tailscaleIp = status.Self?.PrimaryIP;
+
+            return new ServiceHealthInfo
+            {
+                ServiceName = ServiceName,
+                IsHealthy = status.IsConnected,
+                Status = status.BackendState,
+                Message = status.IsConnected
+                    ? $"Connected to {status.TailnetName}"
+                    : "Not connected to tailnet",
+                Metrics = new Dictionary<string, string>
+                {
+                    { "Backend State", status.BackendState },
+                    { "Tailnet", status.TailnetName ?? "N/A" },
+                    { "Tailscale IP", tailscaleIp ?? "N/A" },
+                    { "Online Peers", status.Peers.Count(p => p.Online).ToString() },
+                    { "Total Peers", status.Peers.Count.ToString() },
+                    { "Version", version ?? "Unknown" }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ServiceHealthInfo
+            {
+                ServiceName = ServiceName,
+                IsHealthy = false,
+                Status = "Error",
+                Message = ex.Message
+            };
+        }
+    }
+
+    public async Task<bool> IsTailscaleInstalledAsync()
+    {
+        try
+        {
+            await RunCommandAsync("version");
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<string?> GetVersionAsync()
+    {
+        try
+        {
+            var output = await RunCommandAsync("version");
+            return output?.Split('\n').FirstOrDefault()?.Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<TailscaleStatus> GetStatusAsync()
+    {
+        var output = await RunCommandAsync("status --json");
+
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            throw new InvalidOperationException("Failed to get Tailscale status");
+        }
+
+        return ParseStatus(output);
+    }
+
+    public async Task ConnectAsync()
+    {
+        await RunCommandAsync("up");
+    }
+
+    public async Task DisconnectAsync()
+    {
+        await RunCommandAsync("down");
+    }
+
+    public async Task<string?> GetTailscaleIPAsync()
+    {
+        try
+        {
+            var output = await RunCommandAsync("ip");
+            return output?.Split('\n').FirstOrDefault()?.Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<string> RunCommandAsync(string arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = TailscaleCommand,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"tailscale {arguments} failed (exit {process.ExitCode}): {error.Trim()}");
+        }
+
+        return output;
+    }
+
+    private TailscaleStatus ParseStatus(string jsonOutput)
+    {
+        using var doc = JsonDocument.Parse(jsonOutput);
+        var root = doc.RootElement;
+
+        var status = new TailscaleStatus
+        {
+            BackendState = root.TryGetProperty("BackendState", out var bs)
+                ? bs.GetString() ?? "Unknown"
+                : "Unknown",
+            MagicDNSSuffix = root.TryGetProperty("MagicDNSSuffix", out var suffix)
+                ? suffix.GetString()
+                : null
+        };
+
+        // Use MagicDNSSuffix as tailnet name (e.g. "tailnet-name.ts.net")
+        status.TailnetName = status.MagicDNSSuffix;
+
+        // Parse self node
+        if (root.TryGetProperty("Self", out var selfElement))
+        {
+            status.Self = ParseDevice(selfElement);
+        }
+
+        // Parse peers — it's a map of nodeID -> device
+        if (root.TryGetProperty("Peer", out var peersElement) &&
+            peersElement.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var peerProperty in peersElement.EnumerateObject())
+            {
+                var peer = ParseDevice(peerProperty.Value);
+                peer.Id = peerProperty.Name;
+                status.Peers.Add(peer);
+            }
+        }
+
+        return status;
+    }
+
+    private TailscaleDevice ParseDevice(JsonElement element)
+    {
+        var device = new TailscaleDevice
+        {
+            HostName = element.TryGetProperty("HostName", out var hn)
+                ? hn.GetString() ?? ""
+                : "",
+            DNSName = element.TryGetProperty("DNSName", out var dns)
+                ? dns.GetString() ?? ""
+                : "",
+            OS = element.TryGetProperty("OS", out var os)
+                ? os.GetString() ?? ""
+                : "",
+            Online = element.TryGetProperty("Online", out var online)
+                && online.GetBoolean(),
+            ExitNode = element.TryGetProperty("ExitNode", out var exitNode)
+                && exitNode.GetBoolean(),
+            ExitNodeOption = element.TryGetProperty("ExitNodeOption", out var exitNodeOpt)
+                && exitNodeOpt.GetBoolean()
+        };
+
+        if (element.TryGetProperty("TailscaleIPs", out var ipsElement) &&
+            ipsElement.ValueKind == JsonValueKind.Array)
+        {
+            device.TailscaleIPs = ipsElement.EnumerateArray()
+                .Select(ip => ip.GetString() ?? "")
+                .Where(ip => !string.IsNullOrEmpty(ip))
+                .ToList();
+        }
+
+        if (element.TryGetProperty("LastSeen", out var lastSeen) &&
+            lastSeen.ValueKind == JsonValueKind.String)
+        {
+            if (DateTime.TryParse(lastSeen.GetString(), out var dt))
+            {
+                device.LastSeen = dt;
+            }
+        }
+
+        return device;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `homelab tailscale status/up/down/devices` commands wrapping the `tailscale` CLI
- TailscaleClient shells out to `tailscale` binary and parses JSON output
- Follows existing service pattern (interface, factory, commands)
- No mock — gracefully handles missing tailscale with install instructions

## New commands
- `homelab tailscale status` — connection info, peers, Tailscale IP
- `homelab tailscale up` — connect to tailnet
- `homelab tailscale down` — disconnect from tailnet
- `homelab tailscale devices` — list all tailnet devices (with `--online` filter)

## Test plan
- [ ] `dotnet build` compiles clean
- [ ] `homelab tailscale status` shows connection info (or "not installed" message)
- [ ] `homelab tailscale up/down` toggles connection
- [ ] `homelab tailscale devices --online` filters to online peers
- [ ] From remote device via Tailscale: `homelab quick dog-tv` works