### PR TITLE
feat: enhanced network monitoring with anomaly detection

### DIFF
--- a/src/HomeLab.Cli.Tests/Services/Network/NetworkAnomalyDetectorTests.cs
+++ b/src/HomeLab.Cli.Tests/Services/Network/NetworkAnomalyDetectorTests.cs
@@ -1,0 +1,218 @@
+using FluentAssertions;
+using HomeLab.Cli.Models.EventLog;
+using HomeLab.Cli.Services.Network;
+using Xunit;
+
+namespace HomeLab.Cli.Tests.Services.Network;
+
+public class NetworkAnomalyDetectorTests
+{
+    private readonly NetworkAnomalyDetector _sut = new();
+
+    private static EventLogEntry CreateEntry(
+        DateTime? timestamp = null,
+        string[]? deviceIps = null,
+        long trafficBytes = 0,
+        int criticalAlerts = 0,
+        int highAlerts = 0)
+    {
+        var entry = new EventLogEntry
+        {
+            Timestamp = timestamp ?? DateTime.UtcNow,
+            Network = new NetworkSnapshot
+            {
+                DeviceCount = deviceIps?.Length ?? 0,
+                Devices = (deviceIps ?? Array.Empty<string>())
+                    .Select(ip => new DeviceBrief { Ip = ip })
+                    .ToList()
+            }
+        };
+
+        if (trafficBytes > 0)
+        {
+            entry.Network.Traffic = new TrafficSummary { TotalBytes = trafficBytes };
+        }
+
+        if (criticalAlerts > 0 || highAlerts > 0)
+        {
+            entry.Network.Security = new SecuritySummary
+            {
+                TotalAlerts = criticalAlerts + highAlerts,
+                CriticalCount = criticalAlerts,
+                HighCount = highAlerts,
+                RecentAlerts = new List<AlertBrief>()
+            };
+
+            if (criticalAlerts > 0)
+            {
+                entry.Network.Security.RecentAlerts.Add(new AlertBrief
+                {
+                    Severity = "critical",
+                    Signature = "Test Critical Alert",
+                    SourceIp = "10.0.0.1",
+                    DestinationIp = "192.168.1.1"
+                });
+            }
+
+            if (highAlerts > 0)
+            {
+                entry.Network.Security.RecentAlerts.Add(new AlertBrief
+                {
+                    Severity = "high",
+                    Signature = "Test High Alert",
+                    SourceIp = "10.0.0.2",
+                    DestinationIp = "192.168.1.1"
+                });
+            }
+        }
+
+        return entry;
+    }
+
+    [Fact]
+    public void DetectAnomalies_SingleEvent_ReturnsEmpty()
+    {
+        var events = new List<EventLogEntry> { CreateEntry(deviceIps: new[] { "192.168.1.1" }) };
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetectAnomalies_NoChanges_ReturnsEmpty()
+    {
+        var ips = new[] { "192.168.1.1", "192.168.1.2" };
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: ips, trafficBytes: 1000),
+            CreateEntry(deviceIps: ips, trafficBytes: 1100)
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetectAnomalies_NewDevice_ReturnsNewDeviceAnomaly()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: new[] { "192.168.1.1", "192.168.1.2" }),
+            CreateEntry(deviceIps: new[] { "192.168.1.1", "192.168.1.2", "192.168.1.99" })
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+
+        anomalies.Should().ContainSingle(a => a.Type == "NewDevice");
+        var newDevice = anomalies.First(a => a.Type == "NewDevice");
+        newDevice.Severity.Should().Be("warning");
+        newDevice.Details["ip"].Should().Be("192.168.1.99");
+    }
+
+    [Fact]
+    public void DetectAnomalies_DeviceGone_AfterConsecutivePresence_ReturnsAnomaly()
+    {
+        var allIps = new[] { "192.168.1.1", "192.168.1.2" };
+        var missingIp = new[] { "192.168.1.1" };
+
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: allIps),
+            CreateEntry(deviceIps: allIps),
+            CreateEntry(deviceIps: allIps),
+            CreateEntry(deviceIps: allIps),
+            CreateEntry(deviceIps: missingIp) // .2 disappears after 4 consecutive
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().Contain(a => a.Type == "DeviceGone");
+    }
+
+    [Fact]
+    public void DetectAnomalies_DeviceGone_ShortPresence_NoAnomaly()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: new[] { "192.168.1.1", "192.168.1.2" }),
+            CreateEntry(deviceIps: new[] { "192.168.1.1" }) // .2 only seen once, doesn't trigger
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().NotContain(a => a.Type == "DeviceGone");
+    }
+
+    [Fact]
+    public void DetectAnomalies_TrafficSpike_ReturnsWarning()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(trafficBytes: 1000),
+            CreateEntry(trafficBytes: 1100),
+            CreateEntry(trafficBytes: 900),
+            CreateEntry(trafficBytes: 1050),
+            CreateEntry(trafficBytes: 5000) // 5x the average ~ spike
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().Contain(a => a.Type == "TrafficSpike");
+    }
+
+    [Fact]
+    public void DetectAnomalies_CriticalSecurityAlert_ReturnsCriticalAnomaly()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: new[] { "192.168.1.1" }),
+            CreateEntry(deviceIps: new[] { "192.168.1.1" }, criticalAlerts: 2)
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        var alert = anomalies.FirstOrDefault(a => a.Type == "SecurityAlert");
+        alert.Should().NotBeNull();
+        alert!.Severity.Should().Be("critical");
+    }
+
+    [Fact]
+    public void DetectAnomalies_HighSecurityAlert_ReturnsWarningAnomaly()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: new[] { "192.168.1.1" }),
+            CreateEntry(deviceIps: new[] { "192.168.1.1" }, highAlerts: 3)
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        var alert = anomalies.FirstOrDefault(a => a.Type == "SecurityAlert");
+        alert.Should().NotBeNull();
+        alert!.Severity.Should().Be("warning");
+    }
+
+    [Fact]
+    public void DetectAnomalies_DeviceCountAnomaly_LargeChange_ReturnsWarning()
+    {
+        var events = new List<EventLogEntry>
+        {
+            CreateEntry(deviceIps: Enumerable.Range(1, 10).Select(i => $"192.168.1.{i}").ToArray()),
+            CreateEntry(deviceIps: Enumerable.Range(1, 10).Select(i => $"192.168.1.{i}").ToArray()),
+            CreateEntry(deviceIps: Enumerable.Range(1, 10).Select(i => $"192.168.1.{i}").ToArray()),
+            CreateEntry(deviceIps: Enumerable.Range(1, 10).Select(i => $"192.168.1.{i}").ToArray()),
+            CreateEntry(deviceIps: Enumerable.Range(1, 20).Select(i => $"192.168.1.{i}").ToArray()) // doubled
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().Contain(a => a.Type == "DeviceCountAnomaly");
+    }
+
+    [Fact]
+    public void DetectAnomalies_NullNetworkSnapshot_HandlesGracefully()
+    {
+        var events = new List<EventLogEntry>
+        {
+            new() { Timestamp = DateTime.UtcNow.AddMinutes(-10) },
+            new() { Timestamp = DateTime.UtcNow }
+        };
+
+        var anomalies = _sut.DetectAnomalies(events);
+        anomalies.Should().BeEmpty();
+    }
+
+}

--- a/src/HomeLab.Cli/Commands/Monitor/MonitorCollectCommand.cs
+++ b/src/HomeLab.Cli/Commands/Monitor/MonitorCollectCommand.cs
@@ -87,6 +87,22 @@ public class MonitorCollectCommand : AsyncCommand<MonitorCollectCommand.Settings
                 AnsiConsole.MarkupLine($"  Docker: {entry.Docker.RunningCount}/{entry.Docker.TotalCount} containers running");
             }
 
+            if (entry.Network != null)
+            {
+                var netParts = new List<string> { $"Devices: {entry.Network.DeviceCount}" };
+                if (entry.Network.Traffic != null)
+                {
+                    netParts.Add($"Traffic: {FormatBytes(entry.Network.Traffic.TotalBytes)}");
+                }
+
+                if (entry.Network.Security != null && entry.Network.Security.TotalAlerts > 0)
+                {
+                    netParts.Add($"Alerts: {entry.Network.Security.TotalAlerts} ({entry.Network.Security.CriticalCount}c/{entry.Network.Security.HighCount}h)");
+                }
+
+                AnsiConsole.MarkupLine($"  Network: {string.Join(" | ", netParts)}");
+            }
+
             if (entry.Errors.Count > 0)
             {
                 AnsiConsole.MarkupLine($"  [yellow]Warnings: {entry.Errors.Count}[/]");
@@ -98,5 +114,19 @@ public class MonitorCollectCommand : AsyncCommand<MonitorCollectCommand.Settings
         }
 
         return 0;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] sizes = ["B", "KB", "MB", "GB", "TB"];
+        double len = bytes;
+        var order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+
+        return $"{len:0.#} {sizes[order]}";
     }
 }

--- a/src/HomeLab.Cli/Commands/Network/NetworkAnalyzeCommand.cs
+++ b/src/HomeLab.Cli/Commands/Network/NetworkAnalyzeCommand.cs
@@ -1,0 +1,395 @@
+using System.ComponentModel;
+using HomeLab.Cli.Models.AI;
+using HomeLab.Cli.Models.EventLog;
+using HomeLab.Cli.Services.Abstractions;
+using HomeLab.Cli.Services.Network;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace HomeLab.Cli.Commands.Network;
+
+/// <summary>
+/// Analyzes network event history for anomalies, trends, and security issues.
+/// Optionally sends findings to AI for deeper analysis.
+/// </summary>
+public class NetworkAnalyzeCommand : AsyncCommand<NetworkAnalyzeCommand.Settings>
+{
+    private readonly IEventLogService _eventLogService;
+    private readonly INetworkAnomalyDetector _anomalyDetector;
+    private readonly ILlmService _llmService;
+
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--last <DURATION>")]
+        [Description("Analysis window: 1h, 6h, 12h, 24h, 7d (default: 24h)")]
+        public string Duration { get; set; } = "24h";
+
+        [CommandOption("--ai")]
+        [Description("Include AI-powered analysis of findings")]
+        public bool UseAi { get; set; }
+    }
+
+    public NetworkAnalyzeCommand(
+        IEventLogService eventLogService,
+        INetworkAnomalyDetector anomalyDetector,
+        ILlmService llmService)
+    {
+        _eventLogService = eventLogService;
+        _anomalyDetector = anomalyDetector;
+        _llmService = llmService;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var since = ParseDuration(settings.Duration);
+        var events = await _eventLogService.ReadEventsAsync(since: since);
+
+        if (events.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No events found.[/] Run [cyan]monitor collect[/] to start logging.");
+            return 0;
+        }
+
+        var anomalies = _anomalyDetector.DetectAnomalies(events);
+
+        // Header
+        AnsiConsole.MarkupLine($"[cyan]Network Analysis[/] — {events.Count} snapshots over {settings.Duration}\n");
+
+        // Anomalies table
+        RenderAnomalies(anomalies);
+
+        // Device changes summary
+        RenderDeviceChanges(events);
+
+        // Traffic trend
+        RenderTrafficTrend(events);
+
+        // Security summary
+        RenderSecuritySummary(events);
+
+        // AI analysis
+        if (settings.UseAi)
+        {
+            await RunAiAnalysis(events, anomalies);
+        }
+
+        return 0;
+    }
+
+    private static void RenderAnomalies(List<NetworkAnomaly> anomalies)
+    {
+        if (anomalies.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]No anomalies detected[/]\n");
+            return;
+        }
+
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.BorderColor(Color.Yellow);
+        table.Title("[yellow]Anomalies[/]");
+        table.AddColumn("[yellow]Time[/]");
+        table.AddColumn("[yellow]Severity[/]");
+        table.AddColumn("[yellow]Type[/]");
+        table.AddColumn("[yellow]Description[/]");
+
+        foreach (var a in anomalies)
+        {
+            var sevColor = a.Severity switch
+            {
+                "critical" => "red",
+                "warning" => "yellow",
+                _ => "dim"
+            };
+
+            table.AddRow(
+                a.Timestamp.ToLocalTime().ToString("MM-dd HH:mm"),
+                $"[{sevColor}]{a.Severity}[/]",
+                a.Type,
+                Markup.Escape(a.Description));
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+    }
+
+    private static void RenderDeviceChanges(List<EventLogEntry> events)
+    {
+        var allDevicesSeen = new Dictionary<string, DeviceBrief>();
+        var firstSeen = new Dictionary<string, DateTime>();
+        var lastSeen = new Dictionary<string, DateTime>();
+
+        foreach (var evt in events)
+        {
+            if (evt.Network?.Devices == null)
+            {
+                continue;
+            }
+
+            foreach (var d in evt.Network.Devices)
+            {
+                allDevicesSeen[d.Ip] = d;
+                if (!firstSeen.ContainsKey(d.Ip))
+                {
+                    firstSeen[d.Ip] = evt.Timestamp;
+                }
+
+                lastSeen[d.Ip] = evt.Timestamp;
+            }
+        }
+
+        if (allDevicesSeen.Count == 0)
+        {
+            return;
+        }
+
+        // Devices that appeared after the first snapshot
+        var firstSnapshot = events.First().Network?.Devices?.Select(d => d.Ip).ToHashSet() ?? new HashSet<string>();
+        var newDevices = allDevicesSeen.Keys.Where(ip => !firstSnapshot.Contains(ip)).ToList();
+
+        if (newDevices.Count > 0)
+        {
+            var table = new Table();
+            table.Border(TableBorder.Rounded);
+            table.BorderColor(Color.Green);
+            table.Title($"[green]New Devices ({newDevices.Count})[/]");
+            table.AddColumn("[yellow]IP[/]");
+            table.AddColumn("[yellow]Hostname[/]");
+            table.AddColumn("[yellow]Vendor[/]");
+            table.AddColumn("[yellow]First Seen[/]");
+
+            foreach (var ip in newDevices.Take(20))
+            {
+                var d = allDevicesSeen[ip];
+                table.AddRow(
+                    d.Ip,
+                    Markup.Escape(d.Hostname ?? "-"),
+                    Markup.Escape(d.Vendor ?? "-"),
+                    firstSeen[ip].ToLocalTime().ToString("MM-dd HH:mm"));
+            }
+
+            AnsiConsole.Write(table);
+            AnsiConsole.WriteLine();
+        }
+
+        AnsiConsole.MarkupLine($"[dim]Total unique devices seen: {allDevicesSeen.Count}[/]");
+    }
+
+    private static void RenderTrafficTrend(List<EventLogEntry> events)
+    {
+        var trafficValues = events
+            .Where(e => e.Network?.Traffic != null)
+            .Select(e => e.Network!.Traffic!.TotalBytes)
+            .ToList();
+
+        if (trafficValues.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No traffic data available (ntopng offline?)[/]\n");
+            return;
+        }
+
+        var min = trafficValues.Min();
+        var max = trafficValues.Max();
+        var avg = (long)trafficValues.Average();
+
+        AnsiConsole.MarkupLine($"[cyan]Traffic Trend:[/] min={NetworkAnomalyDetector.FormatBytes(min)} | avg={NetworkAnomalyDetector.FormatBytes(avg)} | max={NetworkAnomalyDetector.FormatBytes(max)}");
+
+        // Show top talkers from latest snapshot
+        var latest = events.Last().Network?.Traffic;
+        if (latest?.TopTalkers.Count > 0)
+        {
+            var table = new Table();
+            table.Border(TableBorder.Simple);
+            table.AddColumn("[yellow]Top Talkers[/]");
+            table.AddColumn("[yellow]Traffic[/]");
+
+            foreach (var t in latest.TopTalkers)
+            {
+                var label = t.Name ?? t.Ip;
+                table.AddRow(Markup.Escape(label), NetworkAnomalyDetector.FormatBytes(t.TotalBytes));
+            }
+
+            AnsiConsole.Write(table);
+        }
+
+        AnsiConsole.WriteLine();
+    }
+
+    private static void RenderSecuritySummary(List<EventLogEntry> events)
+    {
+        var totalCritical = 0;
+        var totalHigh = 0;
+        var totalAlerts = 0;
+        var signatures = new Dictionary<string, int>();
+
+        foreach (var evt in events)
+        {
+            var sec = evt.Network?.Security;
+            if (sec == null)
+            {
+                continue;
+            }
+
+            totalCritical += sec.CriticalCount;
+            totalHigh += sec.HighCount;
+            totalAlerts += sec.TotalAlerts;
+
+            foreach (var alert in sec.RecentAlerts)
+            {
+                if (!signatures.TryAdd(alert.Signature, 1))
+                {
+                    signatures[alert.Signature]++;
+                }
+            }
+        }
+
+        if (totalAlerts == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No security alerts (Suricata offline or clean)[/]\n");
+            return;
+        }
+
+        var critColor = totalCritical > 0 ? "red" : "green";
+        var highColor = totalHigh > 0 ? "yellow" : "green";
+        AnsiConsole.MarkupLine($"[cyan]Security:[/] [{critColor}]{totalCritical} critical[/] | [{highColor}]{totalHigh} high[/] | {totalAlerts} total alerts");
+
+        if (signatures.Count > 0)
+        {
+            var table = new Table();
+            table.Border(TableBorder.Simple);
+            table.AddColumn("[yellow]Top Signatures[/]");
+            table.AddColumn("[yellow]Count[/]");
+
+            foreach (var (sig, count) in signatures.OrderByDescending(s => s.Value).Take(5))
+            {
+                table.AddRow(Markup.Escape(sig), count.ToString());
+            }
+
+            AnsiConsole.Write(table);
+        }
+
+        AnsiConsole.WriteLine();
+    }
+
+    private async Task RunAiAnalysis(List<EventLogEntry> events, List<NetworkAnomaly> anomalies)
+    {
+        if (!await _llmService.IsAvailableAsync())
+        {
+            AnsiConsole.MarkupLine("[red]AI not configured[/] — add services.ai.token to config");
+            return;
+        }
+
+        var prompt = BuildNetworkPrompt(events, anomalies);
+
+        LlmResponse? response = null;
+
+        await AnsiConsole.Status()
+            .StartAsync($"AI analyzing network ({_llmService.ProviderName})...", async ctx =>
+            {
+                ctx.Spinner(Spinner.Known.Dots);
+                response = await _llmService.SendMessageAsync(
+                    "You are a network security analyst for a homelab. Analyze the network data and anomalies. " +
+                    "Focus on: suspicious activity, new unknown devices, unusual traffic patterns, security threats. " +
+                    "Be concise and actionable. Use plain text, no markdown.",
+                    prompt, 512);
+            });
+
+        if (response?.Success == true)
+        {
+            var panel = new Panel(Markup.Escape(response.Content))
+                .Header("[cyan]AI Network Analysis[/]")
+                .BorderColor(Color.Cyan)
+                .RoundedBorder()
+                .Padding(1, 1);
+
+            AnsiConsole.Write(panel);
+            AnsiConsole.WriteLine();
+
+            const decimal inputPricePerMillion = 1.00m;
+            const decimal outputPricePerMillion = 5.00m;
+            var cost = (response.InputTokens * inputPricePerMillion / 1_000_000m)
+                     + (response.OutputTokens * outputPricePerMillion / 1_000_000m);
+            AnsiConsole.MarkupLine($"[dim]Tokens: {response.InputTokens} in, {response.OutputTokens} out (~${cost:F4})[/]");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]AI request failed: {response?.Error ?? "Unknown error"}[/]");
+        }
+    }
+
+    private static string BuildNetworkPrompt(List<EventLogEntry> events, List<NetworkAnomaly> anomalies)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"Network analysis over {events.Count} snapshots ({events.First().Timestamp:g} to {events.Last().Timestamp:g} UTC):");
+        sb.AppendLine();
+
+        // Anomalies
+        if (anomalies.Count > 0)
+        {
+            sb.AppendLine($"Detected anomalies ({anomalies.Count}):");
+            foreach (var a in anomalies.Take(20))
+            {
+                sb.AppendLine($"  [{a.Severity}] {a.Timestamp:HH:mm} {a.Type}: {a.Description}");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Latest device list
+        var latestDevices = events.Last().Network?.Devices;
+        if (latestDevices?.Count > 0)
+        {
+            sb.AppendLine($"Current devices ({latestDevices.Count}):");
+            foreach (var d in latestDevices)
+            {
+                sb.AppendLine($"  {d.Ip} — {d.Hostname ?? d.Vendor ?? "unknown"} (MAC: {d.Mac ?? "?"})");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Traffic
+        var trafficValues = events
+            .Where(e => e.Network?.Traffic != null)
+            .Select(e => e.Network!.Traffic!.TotalBytes)
+            .ToList();
+        if (trafficValues.Count > 0)
+        {
+            sb.AppendLine($"Traffic: min={NetworkAnomalyDetector.FormatBytes(trafficValues.Min())}, avg={NetworkAnomalyDetector.FormatBytes((long)trafficValues.Average())}, max={NetworkAnomalyDetector.FormatBytes(trafficValues.Max())}");
+        }
+
+        // Security alerts
+        var allAlerts = events
+            .Where(e => e.Network?.Security != null)
+            .SelectMany(e => e.Network!.Security!.RecentAlerts)
+            .ToList();
+        if (allAlerts.Count > 0)
+        {
+            sb.AppendLine($"Security alerts ({allAlerts.Count}):");
+            foreach (var a in allAlerts.Take(15))
+            {
+                sb.AppendLine($"  [{a.Severity}] {a.Signature}: {a.SourceIp} -> {a.DestinationIp} ({a.Category ?? "?"})");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static DateTime ParseDuration(string duration)
+    {
+        var now = DateTime.UtcNow;
+        var d = duration.ToLowerInvariant().Trim();
+
+        if (d.EndsWith('h') && int.TryParse(d[..^1], out var hours))
+        {
+            return now.AddHours(-hours);
+        }
+
+        if (d.EndsWith('d') && int.TryParse(d[..^1], out var days))
+        {
+            return now.AddDays(-days);
+        }
+
+        return now.AddHours(-24);
+    }
+}

--- a/src/HomeLab.Cli/Commands/ShellCompletionHandler.cs
+++ b/src/HomeLab.Cli/Commands/ShellCompletionHandler.cs
@@ -26,7 +26,7 @@ public class ShellCompletionHandler : IAutoCompleteHandler
         ["speedtest"] = new[] { "run", "stats" },
         ["ha"] = new[] { "status", "control", "get", "list" },
         ["traefik"] = new[] { "status", "routes", "services", "middlewares" },
-        ["network"] = new[] { "scan", "ports", "devices", "traffic", "intrusion", "status" },
+        ["network"] = new[] { "scan", "ports", "devices", "traffic", "intrusion", "status", "analyze" },
         ["tv"] = new[] { "status", "on", "off", "setup", "apps", "launch", "key", "debug" }
     };
 

--- a/src/HomeLab.Cli/Models/EventLog/EventLogEntry.cs
+++ b/src/HomeLab.Cli/Models/EventLog/EventLogEntry.cs
@@ -61,6 +61,57 @@ public class ContainerBrief
 public class NetworkSnapshot
 {
     public int DeviceCount { get; set; }
+    public List<DeviceBrief> Devices { get; set; } = new();
+    public TrafficSummary? Traffic { get; set; }
+    public SecuritySummary? Security { get; set; }
+}
+
+public class DeviceBrief
+{
+    public string Ip { get; set; } = string.Empty;
+    public string? Mac { get; set; }
+    public string? Hostname { get; set; }
+    public string? Vendor { get; set; }
+}
+
+public class TrafficSummary
+{
+    public long TotalBytes { get; set; }
+    public int ActiveFlows { get; set; }
+    public List<TopTalkerBrief> TopTalkers { get; set; } = new();
+}
+
+public class TopTalkerBrief
+{
+    public string Ip { get; set; } = string.Empty;
+    public string? Name { get; set; }
+    public long TotalBytes { get; set; }
+}
+
+public class SecuritySummary
+{
+    public int TotalAlerts { get; set; }
+    public int CriticalCount { get; set; }
+    public int HighCount { get; set; }
+    public List<AlertBrief> RecentAlerts { get; set; } = new();
+}
+
+public class AlertBrief
+{
+    public string Severity { get; set; } = string.Empty;
+    public string Signature { get; set; } = string.Empty;
+    public string SourceIp { get; set; } = string.Empty;
+    public string DestinationIp { get; set; } = string.Empty;
+    public string? Category { get; set; }
+}
+
+public class NetworkAnomaly
+{
+    public DateTime Timestamp { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Severity { get; set; } = "info";
+    public string Description { get; set; } = string.Empty;
+    public Dictionary<string, string> Details { get; set; } = new();
 }
 
 public class ServiceHealthEntry

--- a/src/HomeLab.Cli/Program.cs
+++ b/src/HomeLab.Cli/Program.cs
@@ -77,6 +77,7 @@ public static class Program
 
         // Network monitoring services
         services.AddSingleton<INmapService, NmapService>();
+        services.AddSingleton<INetworkAnomalyDetector, NetworkAnomalyDetector>();
 
         // TV control services
         services.AddSingleton<IWakeOnLanService, WakeOnLanService>();
@@ -289,6 +290,9 @@ public static class Program
             network.AddCommand<NetworkStatusCommand>("status")
                 .WithAlias("st")
                 .WithDescription("Comprehensive network health overview");
+            network.AddCommand<NetworkAnalyzeCommand>("analyze")
+                .WithAlias("ai")
+                .WithDescription("Analyze network trends and detect anomalies");
         });
 
         // TV Control - LG WebOS Smart TV

--- a/src/HomeLab.Cli/Services/Network/INetworkAnomalyDetector.cs
+++ b/src/HomeLab.Cli/Services/Network/INetworkAnomalyDetector.cs
@@ -1,0 +1,14 @@
+using HomeLab.Cli.Models.EventLog;
+
+namespace HomeLab.Cli.Services.Network;
+
+/// <summary>
+/// Detects network anomalies by comparing event log snapshots.
+/// </summary>
+public interface INetworkAnomalyDetector
+{
+    /// <summary>
+    /// Analyzes a sequence of event log entries and returns detected anomalies.
+    /// </summary>
+    List<NetworkAnomaly> DetectAnomalies(List<EventLogEntry> events);
+}

--- a/src/HomeLab.Cli/Services/Network/NetworkAnomalyDetector.cs
+++ b/src/HomeLab.Cli/Services/Network/NetworkAnomalyDetector.cs
@@ -1,0 +1,247 @@
+using HomeLab.Cli.Models.EventLog;
+
+namespace HomeLab.Cli.Services.Network;
+
+/// <summary>
+/// Pure-logic anomaly detector that compares consecutive network snapshots.
+/// No external dependencies — fully testable.
+/// </summary>
+public class NetworkAnomalyDetector : INetworkAnomalyDetector
+{
+    public List<NetworkAnomaly> DetectAnomalies(List<EventLogEntry> events)
+    {
+        var anomalies = new List<NetworkAnomaly>();
+
+        if (events.Count < 2)
+        {
+            return anomalies;
+        }
+
+        for (var i = 1; i < events.Count; i++)
+        {
+            var prev = events[i - 1];
+            var curr = events[i];
+
+            DetectNewDevices(prev, curr, anomalies);
+            DetectDeviceDisappearances(prev, curr, i, events, anomalies);
+            DetectTrafficSpikes(i, events, anomalies);
+            DetectSecurityAlerts(curr, anomalies);
+            DetectDeviceCountAnomaly(i, events, anomalies);
+        }
+
+        return anomalies;
+    }
+
+    private static void DetectNewDevices(EventLogEntry prev, EventLogEntry curr, List<NetworkAnomaly> anomalies)
+    {
+        var prevIps = prev.Network?.Devices?.Select(d => d.Ip).ToHashSet() ?? new HashSet<string>();
+        var currDevices = curr.Network?.Devices ?? new List<DeviceBrief>();
+
+        foreach (var device in currDevices)
+        {
+            if (!prevIps.Contains(device.Ip))
+            {
+                var info = device.Hostname ?? device.Vendor ?? "unknown";
+                anomalies.Add(new NetworkAnomaly
+                {
+                    Timestamp = curr.Timestamp,
+                    Type = "NewDevice",
+                    Severity = "warning",
+                    Description = $"New device: {device.Ip} ({info})",
+                    Details = new Dictionary<string, string>
+                    {
+                        ["ip"] = device.Ip,
+                        ["mac"] = device.Mac ?? "",
+                        ["hostname"] = device.Hostname ?? "",
+                        ["vendor"] = device.Vendor ?? ""
+                    }
+                });
+            }
+        }
+    }
+
+    private static void DetectDeviceDisappearances(
+        EventLogEntry prev, EventLogEntry curr, int index,
+        List<EventLogEntry> events, List<NetworkAnomaly> anomalies)
+    {
+        var prevIps = prev.Network?.Devices?.Select(d => d.Ip).ToHashSet() ?? new HashSet<string>();
+        var currIps = curr.Network?.Devices?.Select(d => d.Ip).ToHashSet() ?? new HashSet<string>();
+
+        foreach (var ip in prevIps.Except(currIps))
+        {
+            // Only flag if device was seen in 3+ consecutive prior snapshots
+            var consecutiveCount = 0;
+            for (var j = index - 1; j >= 0 && j >= index - 4; j--)
+            {
+                var ips = events[j].Network?.Devices?.Select(d => d.Ip).ToHashSet() ?? new HashSet<string>();
+                if (ips.Contains(ip))
+                {
+                    consecutiveCount++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (consecutiveCount >= 3)
+            {
+                anomalies.Add(new NetworkAnomaly
+                {
+                    Timestamp = curr.Timestamp,
+                    Type = "DeviceGone",
+                    Severity = "info",
+                    Description = $"Device left network: {ip}",
+                    Details = new Dictionary<string, string> { ["ip"] = ip }
+                });
+            }
+        }
+    }
+
+    private static void DetectTrafficSpikes(int index, List<EventLogEntry> events, List<NetworkAnomaly> anomalies)
+    {
+        var curr = events[index];
+        var currBytes = curr.Network?.Traffic?.TotalBytes ?? 0;
+        if (currBytes == 0)
+        {
+            return;
+        }
+
+        // Calculate rolling average of last 6 snapshots
+        var windowStart = Math.Max(0, index - 6);
+        var trafficValues = new List<long>();
+        for (var j = windowStart; j < index; j++)
+        {
+            var bytes = events[j].Network?.Traffic?.TotalBytes ?? 0;
+            if (bytes > 0)
+            {
+                trafficValues.Add(bytes);
+            }
+        }
+
+        if (trafficValues.Count < 2)
+        {
+            return;
+        }
+
+        var avg = trafficValues.Average();
+        if (avg > 0 && currBytes > avg * 3)
+        {
+            anomalies.Add(new NetworkAnomaly
+            {
+                Timestamp = curr.Timestamp,
+                Type = "TrafficSpike",
+                Severity = "warning",
+                Description = $"Traffic spike: {FormatBytes(currBytes)} (avg: {FormatBytes((long)avg)})",
+                Details = new Dictionary<string, string>
+                {
+                    ["currentBytes"] = currBytes.ToString(),
+                    ["averageBytes"] = ((long)avg).ToString()
+                }
+            });
+        }
+    }
+
+    private static void DetectSecurityAlerts(EventLogEntry curr, List<NetworkAnomaly> anomalies)
+    {
+        var security = curr.Network?.Security;
+        if (security == null || security.TotalAlerts == 0)
+        {
+            return;
+        }
+
+        if (security.CriticalCount > 0)
+        {
+            var topAlert = security.RecentAlerts.FirstOrDefault(a => a.Severity == "critical");
+            var sig = topAlert?.Signature ?? "unknown";
+            anomalies.Add(new NetworkAnomaly
+            {
+                Timestamp = curr.Timestamp,
+                Type = "SecurityAlert",
+                Severity = "critical",
+                Description = $"{security.CriticalCount} critical alert(s): {sig}",
+                Details = new Dictionary<string, string>
+                {
+                    ["criticalCount"] = security.CriticalCount.ToString(),
+                    ["highCount"] = security.HighCount.ToString(),
+                    ["signature"] = sig
+                }
+            });
+        }
+        else if (security.HighCount > 0)
+        {
+            var topAlert = security.RecentAlerts.FirstOrDefault(a => a.Severity == "high");
+            var sig = topAlert?.Signature ?? "unknown";
+            anomalies.Add(new NetworkAnomaly
+            {
+                Timestamp = curr.Timestamp,
+                Type = "SecurityAlert",
+                Severity = "warning",
+                Description = $"{security.HighCount} high severity alert(s): {sig}",
+                Details = new Dictionary<string, string>
+                {
+                    ["highCount"] = security.HighCount.ToString(),
+                    ["signature"] = sig
+                }
+            });
+        }
+    }
+
+    private static void DetectDeviceCountAnomaly(int index, List<EventLogEntry> events, List<NetworkAnomaly> anomalies)
+    {
+        var curr = events[index];
+        var currCount = curr.Network?.DeviceCount ?? 0;
+        if (currCount == 0)
+        {
+            return;
+        }
+
+        var windowStart = Math.Max(0, index - 6);
+        var counts = new List<int>();
+        for (var j = windowStart; j < index; j++)
+        {
+            var count = events[j].Network?.DeviceCount ?? 0;
+            if (count > 0)
+            {
+                counts.Add(count);
+            }
+        }
+
+        if (counts.Count < 3)
+        {
+            return;
+        }
+
+        var avg = counts.Average();
+        if (avg > 0 && Math.Abs(currCount - avg) > avg * 0.3)
+        {
+            var direction = currCount > avg ? "increase" : "decrease";
+            anomalies.Add(new NetworkAnomaly
+            {
+                Timestamp = curr.Timestamp,
+                Type = "DeviceCountAnomaly",
+                Severity = "warning",
+                Description = $"Device count {direction}: {currCount} (avg: {avg:F0})",
+                Details = new Dictionary<string, string>
+                {
+                    ["currentCount"] = currCount.ToString(),
+                    ["averageCount"] = avg.ToString("F0")
+                }
+            });
+        }
+    }
+
+    public static string FormatBytes(long bytes)
+    {
+        string[] sizes = ["B", "KB", "MB", "GB", "TB"];
+        double len = bytes;
+        var order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+
+        return $"{len:0.#} {sizes[order]}";
+    }
+}


### PR DESCRIPTION
## Summary

- Enrich periodic event snapshots with **ntopng traffic data** (bytes, flows, top talkers) and **Suricata IDS alerts** (severity counts, recent signatures) collected in parallel alongside existing nmap device scanning
- Add **NetworkAnomalyDetector** service — pure-logic anomaly detection for new devices, disappearances, traffic spikes (>3x rolling avg), security alert escalation, and device count anomalies (>30% change)
- New **`network analyze`** command with `--last` time window and `--ai` flag for AI-powered network analysis
- Enhanced **`monitor history`** with Traffic and Alerts columns, severity-colored alert counts
- Enriched **AI prompts** (`monitor ask`, `monitor report`) with network device changes, security events, and traffic trends
- Enhanced **`monitor collect`** output with network summary line
- **10 unit tests** for NetworkAnomalyDetector covering all detection rules + edge cases

## Changes

| Area | Files | What |
|------|-------|------|
| Models | `EventLogEntry.cs` | `DeviceBrief`, `TrafficSummary`, `SecuritySummary`, `AlertBrief`, `NetworkAnomaly` DTOs |
| Collector | `EventCollector.cs` | Parallel ntopng + Suricata collection with graceful degradation |
| Anomaly Detection | `NetworkAnomalyDetector.cs`, `INetworkAnomalyDetector.cs` | Pure-logic detector, 5 detection rules |
| Commands | `NetworkAnalyzeCommand.cs` | `network analyze [--last 24h] [--ai]` |
| History | `MonitorHistoryCommand.cs` | Traffic + Alerts columns, expanded change detection |
| AI | `SystemDataCollector.cs` | Network sections in event history prompts |
| Output | `MonitorCollectCommand.cs` | Network summary line |
| Wiring | `Program.cs`, `ShellCompletionHandler.cs` | DI + command registration + completions |
| Tests | `NetworkAnomalyDetectorTests.cs` | 10 tests, all passing |

## Test plan

- [x] All 72 tests pass (`dotnet test`)
- [x] Format clean (`dotnet format --verify-no-changes`)
- [x] Binary built and installed
- [ ] CI passes (build + CodeQL)