### PR TITLE
chore: add Makefile with codesign for ARM64 installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+PROJECT = src/HomeLab.Cli/HomeLab.Cli.csproj
+TESTS   = src/HomeLab.Cli.Tests/HomeLab.Cli.Tests.csproj
+OUT     = publish-single
+BIN     = $(HOME)/.local/bin/homelab
+RID     = osx-arm64
+
+.PHONY: build test format publish install clean
+
+build:
+	dotnet build $(PROJECT)
+
+test:
+	dotnet test $(TESTS)
+
+format:
+	dotnet format --verify-no-changes
+
+publish:
+	dotnet publish $(PROJECT) -c Release -r $(RID) --self-contained true /p:PublishSingleFile=true -o $(OUT)
+
+install: publish
+	cp $(OUT)/HomeLab.Cli $(BIN)
+	codesign -f -s - $(BIN)
+	xattr -cr $(BIN)
+	@echo "Installed to $(BIN)"
+
+clean:
+	dotnet clean $(PROJECT)
+	rm -rf $(OUT)


### PR DESCRIPTION
## Summary
- Add Makefile with `build`, `test`, `format`, `publish`, `install`, `clean` targets
- `make install` automatically codesigns and clears quarantine attributes after copy
- Fixes `zsh: killed` issue on Apple Silicon when running unsigned binaries