### PR TITLE
fix: bot daemon log path crashes on external drive

### DIFF
--- a/src/HomeLab.Cli/Commands/Bot/BotScheduleCommand.cs
+++ b/src/HomeLab.Cli/Commands/Bot/BotScheduleCommand.cs
@@ -11,12 +11,9 @@ public class BotScheduleCommand : Command<BotScheduleCommand.Settings>
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         "Library", "LaunchAgents", "com.homelab.bot.plist");
 
-    private const string ExternalDrivePath = "/Volumes/T9";
-
-    private static readonly string LogPath = Directory.Exists(ExternalDrivePath)
-        ? Path.Combine(ExternalDrivePath, ".homelab", "bot.log")
-        : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".homelab", "bot.log");
+    private static readonly string LogPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".homelab", "bot.log");
 
     public class Settings : CommandSettings
     {


### PR DESCRIPTION
## Summary
- Bot daemon was crashing because log path pointed to `/Volumes/T9` which isn't accessible in LaunchAgent context
- Changed to always use `~/.homelab/bot.log`

## Test plan
- [x] `homelab bot schedule install` uses correct log path
- [x] Bot starts successfully as daemon